### PR TITLE
Fix vercel build directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "public",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- remove `outputDirectory: public` from `vercel.json` so Vercel looks in `.next`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68498eebe0cc8331b577d247c4f77f30