### PR TITLE
Add project janij management

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,8 @@ Push the repository to [Vercel](https://vercel.com) and select **Next.js** as th
 
 Create a new **Web Service** on [Render](https://render.com) using this repository. Set the build command to `npm run build` and the start command to `npm run start`. Make sure the required environment variables are configured in the dashboard.
 
+## Database
+
+Run the SQL scripts under `sql/migrations` on your Supabase instance to keep the schema up to date. The file `20240411_add_activo_to_janijim.sql` adds a column used for soft deleting janijim.
+
 

--- a/sql/migrations/20240411_add_activo_to_janijim.sql
+++ b/sql/migrations/20240411_add_activo_to_janijim.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.janijim ADD COLUMN IF NOT EXISTS activo boolean DEFAULT true;

--- a/src/lib/supabase/janijim.ts
+++ b/src/lib/supabase/janijim.ts
@@ -1,0 +1,29 @@
+import { supabase } from "@/lib/supabase";
+
+export async function getJanijim(proyectoId: string) {
+  const { data, error } = await supabase
+    .from("janijim")
+    .select("id, nombre")
+    .eq("proyecto_id", proyectoId)
+    .eq("activo", true)
+    .order("nombre", { ascending: true });
+  if (error) throw error;
+  return data;
+}
+
+export async function addJanijim(proyectoId: string, nombres: string[]) {
+  const payload = nombres.map((nombre) => ({ nombre, proyecto_id: proyectoId }));
+  const { data, error } = await supabase.from("janijim").insert(payload).select();
+  if (error) throw error;
+  return data;
+}
+
+export async function updateJanij(id: string, nombre: string) {
+  const { error } = await supabase.from("janijim").update({ nombre }).eq("id", id);
+  if (error) throw error;
+}
+
+export async function removeJanij(id: string) {
+  const { error } = await supabase.from("janijim").update({ activo: false }).eq("id", id);
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- add migration for `janijim.activo`
- create Supabase helpers for janij CRUD
- persist and manage janijim in asistencia page
- allow import with duplicate handling
- add edit/delete menu per janij
- document migrations in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849a1def8e883319fdb555e877f54d4