### PR TITLE
Add loaders for async pages

### DIFF
--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+import Loader from "@/components/ui/loader";
+
+export default function Loading() {
+  return (
+    <div className="flex justify-center items-center h-32">
+      <Loader className="h-8 w-8" />
+    </div>
+  );
+}

--- a/src/app/dashboard/nuevo/page.tsx
+++ b/src/app/dashboard/nuevo/page.tsx
@@ -4,14 +4,17 @@ import { useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
+import Loader from "@/components/ui/loader";
 
 export default function NuevoProyectoPage() {
   const { user } = useUser();
   const router = useRouter();
   const [nombre, setNombre] = useState("");
+  const [creating, setCreating] = useState(false);
 
   const handleCrear = async () => {
-    if (!user) return;
+    if (!user || creating) return;
+    setCreating(true);
     // Use the imported supabase client directly
 
     // 1. Crear proyecto
@@ -28,9 +31,14 @@ export default function NuevoProyectoPage() {
       .from("madrijim_proyectos")
       .insert({ proyecto_id: proyecto.id, madrij_id: user.id, rol: "creador", invitado: false });
 
-    if (e2) return alert("Error asignando proyecto");
+    if (e2) {
+      alert("Error asignando proyecto");
+      setCreating(false);
+      return;
+    }
 
     router.push(`/proyecto/${proyecto.id}`);
+    setCreating(false);
   };
 
   return (
@@ -45,9 +53,11 @@ export default function NuevoProyectoPage() {
       />
       <button
         onClick={handleCrear}
-        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        disabled={creating}
+        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-75 flex items-center justify-center gap-2"
       >
-        Crear
+        {creating && <Loader className="h-4 w-4" />}
+        <span>Crear</span>
       </button>
     </div>
   );

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import Link from "next/link";
 import { getProyectosParaUsuario } from "@/lib/supabase/projects";
+import Loader from "@/components/ui/loader";
 
 type Proyecto = {
   id: string;
@@ -13,13 +14,16 @@ type Proyecto = {
 export default function DashboardPage() {
   const { user } = useUser();
   const [proyectos, setProyectos] = useState<Proyecto[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!user) return;
 
+    setLoading(true);
     getProyectosParaUsuario(user.id)
       .then((data) => setProyectos(data.flat()))
-      .catch((err) => console.error("Error cargando proyectos", err));
+      .catch((err) => console.error("Error cargando proyectos", err))
+      .finally(() => setLoading(false));
   }, [user]);
 
   return (
@@ -27,15 +31,21 @@ export default function DashboardPage() {
       <h1 className="text-2xl font-bold mb-4">Tus Proyectos</h1>
 
       <div className="space-y-4">
-        {proyectos.map((p) => (
-          <Link
-            key={p.id}
-            href={`/proyecto/${p.id}`}
-            className="block p-4 border rounded-lg hover:bg-gray-100 transition"
-          >
-            {p.nombre}
-          </Link>
-        ))}
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <Loader className="h-6 w-6" />
+          </div>
+        ) : (
+          proyectos.map((p) => (
+            <Link
+              key={p.id}
+              href={`/proyecto/${p.id}`}
+              className="block p-4 border rounded-lg hover:bg-gray-100 transition"
+            >
+              {p.nombre}
+            </Link>
+          ))
+        )}
 
         <Link
           href="/dashboard/nuevo"

--- a/src/app/proyecto/[id]/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/asistencia/page.tsx
@@ -12,6 +12,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { FileUp, EllipsisVertical } from "lucide-react";
+import Loader from "@/components/ui/loader";
 import {
   getJanijim,
   addJanijim,
@@ -35,6 +36,7 @@ export default function AsistenciaPage() {
   const [dupOpen, setDupOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [janijim, setJanijim] = useState<Janij[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [showResults, setShowResults] = useState(false);
   const [highlightId, setHighlightId] = useState<string | null>(null);
@@ -47,13 +49,15 @@ export default function AsistenciaPage() {
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
   useEffect(() => {
+    setLoading(true);
     getJanijim(proyectoId)
       .then((data) =>
         setJanijim(
           data.map((j) => ({ ...j, estado: "ausente" as const }))
         )
       )
-      .catch((err) => console.error("Error cargando janijim", err));
+      .catch((err) => console.error("Error cargando janijim", err))
+      .finally(() => setLoading(false));
   }, [proyectoId]);
 
   const agregar = async (nombre: string) => {
@@ -256,6 +260,14 @@ export default function AsistenciaPage() {
 
     return [...exact, ...aiMatches];
   }, [search, janijim, aiResults]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader className="h-6 w-6" />
+      </div>
+    );
+  }
 
 
   return (

--- a/src/app/proyecto/[id]/loading.tsx
+++ b/src/app/proyecto/[id]/loading.tsx
@@ -1,0 +1,9 @@
+import Loader from "@/components/ui/loader";
+
+export default function Loading() {
+  return (
+    <div className="flex justify-center items-center h-32">
+      <Loader className="h-8 w-8" />
+    </div>
+  );
+}

--- a/src/components/ui/loader.tsx
+++ b/src/components/ui/loader.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils";
+
+export default function Loader({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "animate-spin rounded-full border-4 border-gray-300 border-t-blue-600",
+        className
+      )}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- create a generic `Loader` component
- show loader while fetching projects on dashboard page
- display loader when creating a project
- show loader while fetching janijim
- add route-level loading components for dashboard and project pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849b05871408331bf0a90236f41f42d