### PR TITLE
Add attendance sessions table

### DIFF
--- a/sql/migrations/20250611_create_asistencia_sesiones.sql
+++ b/sql/migrations/20250611_create_asistencia_sesiones.sql
@@ -1,0 +1,20 @@
+-- Create table for attendance sessions
+CREATE TABLE IF NOT EXISTS public.asistencia_sesiones (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    proyecto_id uuid NOT NULL REFERENCES public.proyectos(id),
+    nombre text NOT NULL,
+    inicio timestamp with time zone NOT NULL DEFAULT now(),
+    fecha date NOT NULL,
+    madrij_id text NOT NULL,
+    finalizado boolean DEFAULT false,
+    finalizado_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+-- Link attendance records to a session
+ALTER TABLE public.asistencias
+  ADD COLUMN IF NOT EXISTS sesion_id uuid;
+
+ALTER TABLE public.asistencias
+  ADD CONSTRAINT asistencias_sesion_id_fkey
+    FOREIGN KEY (sesion_id) REFERENCES public.asistencia_sesiones(id);

--- a/sql/migrations/20250612_unique_asistencias.sql
+++ b/sql/migrations/20250612_unique_asistencias.sql
@@ -1,0 +1,4 @@
+-- Avoid duplicate attendance entries per session
+ALTER TABLE public.asistencias
+  ADD CONSTRAINT IF NOT EXISTS asistencia_unique_sesion_janij
+    UNIQUE (sesion_id, janij_id);

--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import Loader from "@/components/ui/loader";
+import {
+  getJanijim,
+} from "@/lib/supabase/janijim";
+import {
+  getAsistencias,
+  marcarAsistencia,
+  finalizarSesion,
+  getSesion,
+} from "@/lib/supabase/asistencias";
+
+export default function AsistenciaPage() {
+  const { id: proyectoId } = useParams<{ id: string }>();
+  const params = useSearchParams();
+  const sesionId = params.get("sesion") || "";
+  const { user } = useUser();
+
+  const [janijim, setJanijim] = useState<{ id: string; nombre: string }[]>([]);
+  const [estado, setEstado] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+  const [sesion, setSesion] = useState<{ nombre: string } | null>(null);
+
+  useEffect(() => {
+    if (!sesionId) return;
+    Promise.all([
+      getSesion(sesionId),
+      getJanijim(proyectoId),
+      getAsistencias(sesionId),
+    ])
+      .then(([s, j, a]) => {
+        setSesion(s);
+        setJanijim(j);
+        const m: Record<string, boolean> = {};
+        a.forEach((r) => {
+          m[r.janij_id] = r.presente;
+        });
+        setEstado(m);
+      })
+      .finally(() => setLoading(false));
+  }, [sesionId, proyectoId]);
+
+  const toggle = async (janijId: string) => {
+    if (!user || !sesionId) return;
+    const nuevo = !estado[janijId];
+    setEstado((p) => ({ ...p, [janijId]: nuevo }));
+    try {
+      await marcarAsistencia(
+        sesionId,
+        proyectoId,
+        janijId,
+        user.id,
+        nuevo
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const finalizar = async () => {
+    await finalizarSesion(sesionId);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader className="h-6 w-6" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto mt-12 space-y-4">
+      <h2 className="text-xl font-semibold">{sesion?.nombre}</h2>
+      <ul className="space-y-2">
+        {janijim.map((j) => (
+          <li key={j.id} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={!!estado[j.id]}
+              onChange={() => toggle(j.id)}
+            />
+            <span>{j.nombre}</span>
+          </li>
+        ))}
+      </ul>
+      <button
+        onClick={finalizar}
+        className="px-4 py-2 bg-green-600 text-white rounded"
+      >
+        Finalizar asistencia
+      </button>
+    </div>
+  );
+}

--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useMemo, useRef, useEffect } from "react";
 import * as XLSX from "xlsx";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
 import {
   Sheet,
   SheetContent,
@@ -19,6 +20,8 @@ import {
   updateJanij,
   removeJanij,
 } from "@/lib/supabase/janijim";
+import { crearSesion } from "@/lib/supabase/asistencias";
+import { getMadrijimPorProyecto } from "@/lib/supabase/madrijim";
 
 type Janij = {
   id: string;
@@ -26,8 +29,10 @@ type Janij = {
   estado: "presente" | "ausente";
 };
 
-export default function AsistenciaPage() {
+export default function JanijimPage() {
   const { id: proyectoId } = useParams<{ id: string }>();
+  const { user } = useUser();
+  const router = useRouter();
   const fileInput = useRef<HTMLInputElement>(null);
   const [columns, setColumns] = useState<string[]>([]);
   const [rows, setRows] = useState<string[][]>([]);
@@ -47,6 +52,13 @@ export default function AsistenciaPage() {
   const [selectedDupes, setSelectedDupes] = useState<string[]>([]);
   const [importText, setImportText] = useState("");
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [sesionOpen, setSesionOpen] = useState(false);
+  const [sesionNombre, setSesionNombre] = useState("");
+  const [sesionFecha, setSesionFecha] = useState(
+    new Date().toISOString().slice(0, 16)
+  );
+  const [madrijes, setMadrijes] = useState<{ clerk_id: string; nombre: string }[]>([]);
+  const [sesionMadrij, setSesionMadrij] = useState<string>("");
 
   useEffect(() => {
     setLoading(true);
@@ -59,6 +71,16 @@ export default function AsistenciaPage() {
       .catch((err) => console.error("Error cargando janijim", err))
       .finally(() => setLoading(false));
   }, [proyectoId]);
+
+  useEffect(() => {
+    if (!proyectoId) return;
+    getMadrijimPorProyecto(proyectoId)
+      .then((m) => {
+        setMadrijes(m);
+        if (m.length > 0 && !sesionMadrij) setSesionMadrij(m[0].clerk_id);
+      })
+      .catch((err) => console.error("Error cargando madrijim", err));
+  }, [proyectoId, sesionMadrij]);
 
   const agregar = async (nombre: string) => {
     try {
@@ -217,6 +239,23 @@ export default function AsistenciaPage() {
     setDupOpen(false);
   };
 
+  const iniciarSesion = async () => {
+    if (!user) return;
+    try {
+      const sesion = await crearSesion(
+        proyectoId,
+        sesionNombre || "Asistencia",
+        sesionFecha.split("T")[0],
+        sesionMadrij || user.id
+      );
+      router.push(
+        `/proyecto/${proyectoId}/janijim/asistencia?sesion=${sesion.id}`
+      );
+    } catch {
+      alert("Error iniciando asistencia");
+    }
+  };
+
   useEffect(() => {
     if (!search.trim()) {
       setAiResults([]);
@@ -272,6 +311,12 @@ export default function AsistenciaPage() {
 
   return (
     <div className="max-w-2xl mx-auto mt-12 space-y-4">
+      <button
+        onClick={() => setSesionOpen(true)}
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Iniciar asistencia del día
+      </button>
       <div className="relative flex items-center gap-2">
         <input
           type="text"
@@ -522,6 +567,51 @@ export default function AsistenciaPage() {
               className="px-4 py-2 bg-blue-600 text-white rounded-lg"
             >
               Importar
+            </button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={sesionOpen} onOpenChange={setSesionOpen}>
+        <SheetContent side="bottom" className="w-full">
+          <SheetHeader>
+            <SheetTitle>Nueva toma de asistencia</SheetTitle>
+            <SheetDescription>
+              Ingresá el nombre, fecha y madrij encargado.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="p-4 space-y-4">
+            <input
+              type="text"
+              value={sesionNombre}
+              onChange={(e) => setSesionNombre(e.target.value)}
+              placeholder="Nombre de la sesión"
+              className="w-full border rounded-lg p-2"
+            />
+            <input
+              type="datetime-local"
+              value={sesionFecha}
+              onChange={(e) => setSesionFecha(e.target.value)}
+              className="w-full border rounded-lg p-2"
+            />
+            <select
+              className="w-full border rounded-lg p-2"
+              value={sesionMadrij}
+              onChange={(e) => setSesionMadrij(e.target.value)}
+            >
+              {madrijes.map((m) => (
+                <option key={m.clerk_id} value={m.clerk_id}>
+                  {m.nombre}
+                </option>
+              ))}
+            </select>
+          </div>
+          <SheetFooter>
+            <button
+              onClick={iniciarSesion}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+            >
+              Iniciar
             </button>
           </SheetFooter>
         </SheetContent>

--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -17,7 +17,7 @@ type MobileMenuProps = {
 };
 
 const links = [
-  { href: "asistencia", label: "Asistencia" },
+  { href: "janijim", label: "Janijim" },
   { href: "notas", label: "Notas" },
   { href: "calendario", label: "Calendario" },
   { href: "tareas", label: "Tareas" },

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 
 const links = [
-  { href: "asistencia", label: "Asistencia", icon: ClipboardList },
+  { href: "janijim", label: "Janijim", icon: ClipboardList },
   { href: "notas", label: "Notas", icon: Book },
   { href: "calendario", label: "Calendario", icon: Calendar },
   { href: "tareas", label: "Tareas", icon: CheckSquare },

--- a/src/lib/supabase/asistencias.ts
+++ b/src/lib/supabase/asistencias.ts
@@ -1,0 +1,75 @@
+import { supabase } from "@/lib/supabase";
+
+export async function crearSesion(
+  proyectoId: string,
+  nombre: string,
+  fecha: string,
+  madrijId: string
+) {
+  const { data, error } = await supabase
+    .from("asistencia_sesiones")
+    .insert({ proyecto_id: proyectoId, nombre, fecha, madrij_id: madrijId })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function getSesion(id: string) {
+  const { data, error } = await supabase
+    .from("asistencia_sesiones")
+    .select("*")
+    .eq("id", id)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function getSesionActiva(proyectoId: string) {
+  const { data, error } = await supabase
+    .from("asistencia_sesiones")
+    .select("*")
+    .eq("proyecto_id", proyectoId)
+    .eq("finalizado", false)
+    .single();
+  if (error && error.code !== "PGRST116") throw error;
+  return data;
+}
+
+export async function finalizarSesion(id: string) {
+  const { error } = await supabase
+    .from("asistencia_sesiones")
+    .update({ finalizado: true, finalizado_at: new Date().toISOString() })
+    .eq("id", id);
+  if (error) throw error;
+}
+
+export async function getAsistencias(sesionId: string) {
+  const { data, error } = await supabase
+    .from("asistencias")
+    .select("janij_id, presente")
+    .eq("sesion_id", sesionId);
+  if (error) throw error;
+  return data;
+}
+
+export async function marcarAsistencia(
+  sesionId: string,
+  proyectoId: string,
+  janijId: string,
+  madrijId: string,
+  presente: boolean
+) {
+  const { error } = await supabase.from("asistencias").upsert(
+    {
+      sesion_id: sesionId,
+      proyecto_id: proyectoId,
+      janij_id: janijId,
+      madrij_id: madrijId,
+      fecha: new Date().toISOString().split("T")[0],
+      presente,
+    },
+    { onConflict: "sesion_id,janij_id" }
+  );
+  if (error) throw error;
+}

--- a/src/lib/supabase/madrijim.ts
+++ b/src/lib/supabase/madrijim.ts
@@ -1,0 +1,17 @@
+import { supabase } from "@/lib/supabase";
+
+export async function getMadrijimPorProyecto(proyectoId: string) {
+  const { data: relaciones, error } = await supabase
+    .from("madrijim_proyectos")
+    .select("madrij_id")
+    .eq("proyecto_id", proyectoId);
+  if (error) throw error;
+  const ids = relaciones.map((r) => r.madrij_id);
+  if (ids.length === 0) return [];
+  const { data: madrijim, error: e2 } = await supabase
+    .from("madrijim")
+    .select("clerk_id, nombre")
+    .in("clerk_id", ids);
+  if (e2) throw e2;
+  return madrijim;
+}


### PR DESCRIPTION
## Summary
- add migration for `asistencia_sesiones` table
- link `asistencias` with the new sessions table
- new Janijim section with option to start attendance sessions
- add subpage for recording daily attendance

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849c078a9908331bbaa76a53bfa33cc