### PR TITLE
Improve janij search highlighting

### DIFF
--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo } from "react";
 import * as XLSX from "xlsx";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
+import useHighlightScroll from "@/hooks/useHighlightScroll";
 import Loader from "@/components/ui/loader";
 import {
   getJanijim,
@@ -31,7 +32,7 @@ export default function AsistenciaPage() {
   const [showResults, setShowResults] = useState(false);
   const [aiResults, setAiResults] = useState<string[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
-  const [highlightId, setHighlightId] = useState<string | null>(null);
+  const { highlightId, scrollTo } = useHighlightScroll({ prefix: "janij-" });
 
   useEffect(() => {
     if (!sesionId) return;
@@ -99,10 +100,7 @@ export default function AsistenciaPage() {
   const seleccionar = (id: string) => {
     setShowResults(false);
     setSearch("");
-    setHighlightId(id);
-    const el = document.getElementById(`janij-${id}`);
-    el?.scrollIntoView({ behavior: "smooth", block: "center" });
-    setTimeout(() => setHighlightId(null), 2000);
+    scrollTo(id);
   };
 
   const toggle = async (janijId: string) => {
@@ -243,7 +241,9 @@ export default function AsistenciaPage() {
             id={`janij-${j.id}`}
             key={j.id}
             className={`flex items-center justify-between bg-white shadow p-4 rounded-lg ${
-              highlightId === j.id ? "ring-2 ring-blue-500" : ""
+              highlightId === j.id
+                ? "ring-2 ring-blue-500 animate-pulse"
+                : ""
             }`}
           >
             <label className="flex items-center gap-2">

--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useRef, useEffect } from "react";
 import * as XLSX from "xlsx";
 import { useParams, useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
+import useHighlightScroll from "@/hooks/useHighlightScroll";
 import {
   Sheet,
   SheetContent,
@@ -44,7 +45,7 @@ export default function JanijimPage() {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [showResults, setShowResults] = useState(false);
-  const [highlightId, setHighlightId] = useState<string | null>(null);
+  const { highlightId, scrollTo } = useHighlightScroll({ prefix: "janij-" });
   const [aiResults, setAiResults] = useState<string[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
   const [uniqueNames, setUniqueNames] = useState<string[]>([]);
@@ -103,10 +104,7 @@ export default function JanijimPage() {
   const seleccionar = (id: string) => {
     setShowResults(false);
     setSearch("");
-    setHighlightId(id);
-    const el = document.getElementById(`janij-${id}`);
-    el?.scrollIntoView({ behavior: "smooth", block: "center" });
-    setTimeout(() => setHighlightId(null), 2000);
+    scrollTo(id);
   };
 
 
@@ -415,7 +413,9 @@ export default function JanijimPage() {
             id={`janij-${janij.id}`}
             key={janij.id}
             className={`flex items-center justify-between bg-white shadow p-4 rounded-lg ${
-              highlightId === janij.id ? "ring-2 ring-blue-500" : ""
+              highlightId === janij.id
+                ? "ring-2 ring-blue-500 animate-pulse"
+                : ""
             }`}
           >
             <span>{janij.nombre}</span>

--- a/src/hooks/useHighlightScroll.ts
+++ b/src/hooks/useHighlightScroll.ts
@@ -1,0 +1,25 @@
+"use client";
+import { useState, useCallback } from "react";
+
+type Options = {
+  timeout?: number;
+  prefix?: string;
+};
+
+export default function useHighlightScroll({ timeout = 2000, prefix = "" }: Options = {}) {
+  const [highlightId, setHighlightId] = useState<string | null>(null);
+
+  const scrollTo = useCallback(
+    (id: string) => {
+      setHighlightId(id);
+      const el = document.getElementById(`${prefix}${id}`);
+      el?.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (timeout > 0) {
+        setTimeout(() => setHighlightId(null), timeout);
+      }
+    },
+    [timeout, prefix]
+  );
+
+  return { highlightId, scrollTo };
+}


### PR DESCRIPTION
## Summary
- add `useHighlightScroll` hook for smooth scrolling and highlighting
- use the hook in Janij listing and attendance pages
- animate highlighted rows so selected janijim stand out

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849d07485c883318ff68afe2d747fc1