### PR TITLE
Implement project sharing with invite codes

### DIFF
--- a/sql/migrations/20250613_invite_codes.sql
+++ b/sql/migrations/20250613_invite_codes.sql
@@ -1,0 +1,8 @@
+-- Add invitation code for sharing projects
+ALTER TABLE public.proyectos
+  ADD COLUMN IF NOT EXISTS codigo_invite uuid DEFAULT uuid_generate_v4() UNIQUE;
+
+-- Avoid duplicate members in a project
+ALTER TABLE public.madrijim_proyectos
+  ADD CONSTRAINT IF NOT EXISTS madrijim_proyectos_unique
+    UNIQUE (proyecto_id, madrij_id);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -53,6 +53,12 @@ export default function DashboardPage() {
         >
           + Crear nuevo proyecto
         </Link>
+        <Link
+          href="/dashboard/unirse"
+          className="inline-block px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition"
+        >
+          + Unirse a proyecto
+        </Link>
       </div>
     </div>
   );

--- a/src/app/dashboard/unirse/page.tsx
+++ b/src/app/dashboard/unirse/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+import Loader from "@/components/ui/loader";
+
+export default function UnirseProyectoPage() {
+  const { user } = useUser();
+  const router = useRouter();
+  const [codigo, setCodigo] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleJoin = async () => {
+    if (!user || !codigo || loading) return;
+    setLoading(true);
+    const { data: proyecto, error } = await supabase
+      .from("proyectos")
+      .select("id")
+      .eq("codigo_invite", codigo)
+      .single();
+
+    if (!proyecto || error) {
+      alert("Código inválido");
+      setLoading(false);
+      return;
+    }
+
+    const { error: e2 } = await supabase
+      .from("madrijim_proyectos")
+      .insert({ proyecto_id: proyecto.id, madrij_id: user.id, invitado: false });
+
+    if (e2 && e2.code !== "23505") {
+      alert("Error uniéndose al proyecto");
+      setLoading(false);
+      return;
+    }
+
+    router.push(`/proyecto/${proyecto.id}`);
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Unirse a un Proyecto</h1>
+      <input
+        type="text"
+        placeholder="Código de invitación"
+        className="p-2 border rounded w-full mb-4"
+        value={codigo}
+        onChange={(e) => setCodigo(e.target.value)}
+      />
+      <button
+        onClick={handleJoin}
+        disabled={loading}
+        className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-75 flex items-center gap-2"
+      >
+        {loading && <Loader className="h-4 w-4" />}
+        <span>Unirse</span>
+      </button>
+    </div>
+  );
+}

--- a/src/app/proyecto/[id]/page.tsx
+++ b/src/app/proyecto/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { supabase } from "@/lib/supabase";
+import { getMadrijimPorProyecto } from "@/lib/supabase/madrijim";
 
 // ✅ Tipo correcto para páginas dinámicas
 interface PageProps {
@@ -30,7 +31,7 @@ export default async function ProyectoHome({ params }: PageProps) {
 
   const { data: proyecto, error: errorProyecto } = await supabase
     .from("proyectos")
-    .select("nombre")
+    .select("nombre, codigo_invite")
     .eq("id", proyectoId)
     .single();
 
@@ -38,12 +39,23 @@ export default async function ProyectoHome({ params }: PageProps) {
     return <div className="p-6">Error cargando el proyecto</div>;
   }
 
+  const madrijim = await getMadrijimPorProyecto(proyectoId);
+
   return (
-    <div className="p-6">
-      <h1 className="text-3xl font-bold mb-4">{proyecto.nombre}</h1>
+    <div className="p-6 space-y-4">
+      <h1 className="text-3xl font-bold">{proyecto.nombre}</h1>
       <p className="text-gray-600">
-        ¡Estás dentro de este proyecto! Usá el menú lateral para acceder a asistencia, notas, planificaciones y más.
+        ¡Estás dentro de este proyecto! Compartí el siguiente código con otros madrijim para que se unan:
       </p>
+      <div className="bg-gray-100 p-4 rounded font-mono break-all">
+        {proyecto.codigo_invite}
+      </div>
+      <h2 className="text-xl font-semibold mt-6">Madrijim en este proyecto</h2>
+      <ul className="list-disc list-inside space-y-1">
+        {madrijim.map((m) => (
+          <li key={m.clerk_id}>{m.nombre}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -17,6 +17,7 @@ type MobileMenuProps = {
 };
 
 const links = [
+  { href: "", label: "Inicio" },
   { href: "janijim", label: "Janijim" },
   { href: "notas", label: "Notas" },
   { href: "calendario", label: "Calendario" },
@@ -45,8 +46,10 @@ export default function MobileMenu({ proyectoId }: MobileMenuProps) {
 
           <nav className="space-y-4 mt-6">
             {links.map(({ href, label }) => {
-              const fullPath = `/proyecto/${proyectoId}/${href}`;
-              const isActive = pathname === fullPath;
+              const fullPath = href
+                ? `/proyecto/${proyectoId}/${href}`
+                : `/proyecto/${proyectoId}`;
+              const isActive = pathname === fullPath || pathname === fullPath + "/";
 
               return (
                 <Link

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -10,10 +10,12 @@ import {
   CheckSquare,
   PencilRuler,
   PartyPopper,
-  Bot
+  Bot,
+  Home
 } from "lucide-react";
 
 const links = [
+  { href: "", label: "Inicio", icon: Home },
   { href: "janijim", label: "Janijim", icon: ClipboardList },
   { href: "notas", label: "Notas", icon: Book },
   { href: "calendario", label: "Calendario", icon: Calendar },
@@ -30,8 +32,10 @@ export default function Sidebar({ proyectoId }: { proyectoId: string }) {
     <aside className="hidden md:block w-64 bg-white border-r p-4">
       <nav className="space-y-2">
         {links.map(({ href, label, icon: Icon }) => {
-          const fullPath = `/proyecto/${proyectoId}/${href}`;
-          const isActive = pathname === fullPath;
+          const fullPath = href
+            ? `/proyecto/${proyectoId}/${href}`
+            : `/proyecto/${proyectoId}`;
+          const isActive = pathname === fullPath || pathname === fullPath + "/";
 
           return (
             <Link


### PR DESCRIPTION
## Summary
- enable project home link in sidebar and mobile menu
- allow joining projects from /dashboard/unirse
- display invite code and members on project home page
- link to join projects from dashboard
- add migration for invite codes and unique project members

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849daae3ce88331b28cfc9daec35363