### PR TITLE
Implement real‑time attendance sessions

### DIFF
--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -15,6 +15,18 @@ import {
   finalizarSesion,
   getSesion,
 } from "@/lib/supabase/asistencias";
+import { supabase } from "@/lib/supabase";
+
+type AsistenciaRow = {
+  janij_id: string;
+  presente: boolean;
+  madrij_id: string;
+};
+
+type SesionRow = {
+  finalizado: boolean;
+  madrij_id: string;
+};
 
 export default function AsistenciaPage() {
   const { id: proyectoId } = useParams<{ id: string }>();
@@ -26,13 +38,15 @@ export default function AsistenciaPage() {
   const [janijim, setJanijim] = useState<{ id: string; nombre: string }[]>([]);
   const [estado, setEstado] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
-  const [sesion, setSesion] = useState<{ nombre: string } | null>(null);
+  const [sesion, setSesion] = useState<{ nombre: string; madrij_id: string } | null>(null);
   const [finalizado, setFinalizado] = useState(false);
+  const [updating, setUpdating] = useState(false);
   const [search, setSearch] = useState("");
   const [showResults, setShowResults] = useState(false);
   const [aiResults, setAiResults] = useState<string[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
   const { highlightId, scrollTo } = useHighlightScroll({ prefix: "janij-" });
+  const esCreador = user?.id === sesion?.madrij_id;
 
   useEffect(() => {
     if (!sesionId) return;
@@ -103,6 +117,53 @@ export default function AsistenciaPage() {
     scrollTo(id);
   };
 
+  useEffect(() => {
+    if (!sesionId) return;
+
+    const attendance = supabase
+      .channel(`asist-${sesionId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "asistencias",
+          filter: `sesion_id=eq.${sesionId}`,
+        },
+        (payload) => {
+          const data = payload.new as AsistenciaRow;
+          setEstado((p) => ({ ...p, [data.janij_id]: data.presente }));
+          if (data.madrij_id !== user?.id) {
+            setUpdating(true);
+            setTimeout(() => setUpdating(false), 300);
+          }
+        }
+      )
+      .subscribe();
+
+    const sesionChan = supabase
+      .channel(`ses-end-${sesionId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "asistencia_sesiones",
+          filter: `id=eq.${sesionId}`,
+        },
+        (payload) => {
+          const data = payload.new as SesionRow;
+          if (data.finalizado) setFinalizado(true);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(attendance);
+      supabase.removeChannel(sesionChan);
+    };
+  }, [sesionId, user?.id]);
+
   const toggle = async (janijId: string) => {
     if (!user || !sesionId) return;
     const nuevo = !estado[janijId];
@@ -138,10 +199,8 @@ export default function AsistenciaPage() {
     const ausentes = janijim.filter((j) => !estado[j.id]);
 
     const exportar = () => {
-      const data = janijim.map((j) => ({
-        nombre: j.nombre,
-        presente: estado[j.id] ? "Si" : "No",
-      }));
+      const presentes = janijim.filter((j) => estado[j.id]);
+      const data = presentes.map((j) => ({ nombre: j.nombre }));
       const ws = XLSX.utils.json_to_sheet(data);
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, "Asistencia");
@@ -161,12 +220,14 @@ export default function AsistenciaPage() {
           <p>Presentes: {presentes.length}</p>
           <p>Ausentes: {ausentes.length}</p>
         </div>
-        <button
-          onClick={exportar}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg w-full"
-        >
-          Descargar Excel
-        </button>
+        {esCreador && (
+          <button
+            onClick={exportar}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg w-full"
+          >
+            Descargar Excel
+          </button>
+        )}
         <button
           onClick={() => router.push(`/proyecto/${proyectoId}/janijim`)}
           className="px-4 py-2 bg-green-600 text-white rounded-lg w-full"
@@ -178,8 +239,14 @@ export default function AsistenciaPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto mt-12 space-y-4">
-      <h2 className="text-xl font-semibold">{sesion?.nombre}</h2>
+    <div className="relative">
+      {updating && (
+        <div className="absolute inset-0 bg-white/70 flex items-center justify-center z-10">
+          <Loader className="h-6 w-6" />
+        </div>
+      )}
+      <div className="max-w-2xl mx-auto mt-12 space-y-4">
+        <h2 className="text-xl font-semibold">{sesion?.nombre}</h2>
       <div className="relative flex items-center gap-2">
         <input
           type="text"
@@ -258,12 +325,15 @@ export default function AsistenciaPage() {
           </li>
         ))}
       </ul>
-      <button
-        onClick={finalizar}
-        className="px-4 py-2 bg-green-600 text-white rounded-lg w-full"
-      >
-        Finalizar asistencia
-      </button>
+        {esCreador && (
+          <button
+            onClick={finalizar}
+            className="px-4 py-2 bg-green-600 text-white rounded-lg w-full"
+          >
+            Finalizar asistencia
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/sheet";
 import { FileUp, EllipsisVertical } from "lucide-react";
 import Loader from "@/components/ui/loader";
+import ActiveSesionCard from "@/components/active-sesion-card";
 import {
   getJanijim,
   addJanijim,
@@ -308,6 +309,7 @@ export default function JanijimPage() {
 
   return (
     <div className="max-w-2xl mx-auto mt-12 space-y-4">
+      <ActiveSesionCard proyectoId={proyectoId} />
       <button
         onClick={() => setSesionOpen(true)}
         className="px-4 py-2 bg-blue-600 text-white rounded"

--- a/src/app/proyecto/[id]/page.tsx
+++ b/src/app/proyecto/[id]/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { getMadrijimPorProyecto } from "@/lib/supabase/madrijim-server";
+import ActiveSesionCard from "@/components/active-sesion-card";
 
 
 // ✅ Tipo correcto para páginas dinámicas
@@ -56,6 +57,7 @@ export default async function ProyectoHome({ params }: PageProps) {
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-3xl font-bold">{proyecto.nombre}</h1>
+      <ActiveSesionCard proyectoId={proyectoId} />
       <p className="text-gray-600">
         ¡Estás dentro de este proyecto! Compartí el siguiente código con otros madrijim para que se unan:
       </p>

--- a/src/components/active-sesion-card.tsx
+++ b/src/components/active-sesion-card.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { supabase } from "@/lib/supabase";
+import { getSesionActiva } from "@/lib/supabase/asistencias";
+import { getMadrijNombre } from "@/lib/supabase/madrijim";
+
+type SesionData = {
+  id: string;
+  nombre: string;
+  inicio: string;
+  madrij_id: string;
+  finalizado: boolean;
+};
+
+export default function ActiveSesionCard({ proyectoId }: { proyectoId: string }) {
+  const [sesion, setSesion] = useState<SesionData | null>(null);
+  const [madrijNombre, setMadrijNombre] = useState<string>("");
+
+  useEffect(() => {
+    let ignore = false;
+    const load = async () => {
+      try {
+        const s = await getSesionActiva(proyectoId);
+        if (s && !ignore) {
+          setSesion(s as SesionData);
+          getMadrijNombre(s.madrij_id)
+            .then((n) => !ignore && setMadrijNombre(n))
+            .catch(() => {});
+        }
+      } catch {
+        /* empty */
+      }
+    };
+    load();
+
+    const channel = supabase
+      .channel(`sesiones-${proyectoId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "asistencia_sesiones",
+          filter: `proyecto_id=eq.${proyectoId}`,
+        },
+        (payload) => {
+          const data = payload.new as SesionData;
+          if (data.finalizado) {
+            setSesion(null);
+          } else {
+            setSesion(data);
+            getMadrijNombre(data.madrij_id)
+              .then((n) => setMadrijNombre(n))
+              .catch(() => {});
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      ignore = true;
+      supabase.removeChannel(channel);
+    };
+  }, [proyectoId]);
+
+  if (!sesion) return null;
+
+  const mins = Math.floor((Date.now() - new Date(sesion.inicio).getTime()) / 60000);
+  const ago = mins < 1 ? "hace menos de un minuto" : `hace ${mins} min`;
+
+  return (
+    <Link
+      href={`/proyecto/${proyectoId}/janijim/asistencia?sesion=${sesion.id}`}
+      className="block p-4 bg-yellow-100 border rounded-lg"
+    >
+      <p className="font-semibold">Asistencia en curso</p>
+      <p className="text-sm">Iniciada por {madrijNombre || ""} {ago}</p>
+    </Link>
+  );
+}

--- a/src/lib/supabase/madrijim.ts
+++ b/src/lib/supabase/madrijim.ts
@@ -16,3 +16,13 @@ export async function getMadrijimPorProyecto(proyectoId: string) {
   if (e2) throw e2;
   return madrijim;
 }
+
+export async function getMadrijNombre(clerkId: string) {
+  const { data, error } = await supabase
+    .from("madrijim")
+    .select("nombre")
+    .eq("clerk_id", clerkId)
+    .single();
+  if (error) throw error;
+  return data.nombre as string;
+}


### PR DESCRIPTION
## Summary
- add helper to fetch madrij name
- show live attendance notice on project home and janijim pages
- implement `ActiveSesionCard` component
- add real-time syncing in attendance page with overlay loader
- limit finishing/exporting session to its creator and export only present names

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a0e7d017c83319224d5d5be6b223e