### PR TITLE
Implement real‑time attendance sessions

### DIFF
--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -6,15 +6,25 @@ import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import useHighlightScroll from "@/hooks/useHighlightScroll";
 import Loader from "@/components/ui/loader";
-import {
-  getJanijim,
-} from "@/lib/supabase/janijim";
+import { getJanijim } from "@/lib/supabase/janijim";
 import {
   getAsistencias,
   marcarAsistencia,
   finalizarSesion,
   getSesion,
 } from "@/lib/supabase/asistencias";
+import { supabase } from "@/lib/supabase";
+
+type AsistenciaRow = {
+  janij_id: string;
+  presente: boolean;
+  madrij_id: string;
+};
+
+type SesionRow = {
+  finalizado: boolean;
+  madrij_id: string;
+};
 
 export default function AsistenciaPage() {
   const { id: proyectoId } = useParams<{ id: string }>();
@@ -26,13 +36,18 @@ export default function AsistenciaPage() {
   const [janijim, setJanijim] = useState<{ id: string; nombre: string }[]>([]);
   const [estado, setEstado] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
-  const [sesion, setSesion] = useState<{ nombre: string } | null>(null);
+  const [sesion, setSesion] = useState<{
+    nombre: string;
+    madrij_id: string;
+  } | null>(null);
   const [finalizado, setFinalizado] = useState(false);
+  const [updating, setUpdating] = useState(false);
   const [search, setSearch] = useState("");
   const [showResults, setShowResults] = useState(false);
   const [aiResults, setAiResults] = useState<string[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
   const { highlightId, scrollTo } = useHighlightScroll({ prefix: "janij-" });
+  const esCreador = user?.id === sesion?.madrij_id;
 
   useEffect(() => {
     if (!sesionId) return;
@@ -65,7 +80,10 @@ export default function AsistenciaPage() {
     fetch("/api/search", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query: search, names: janijim.map((j) => j.nombre) }),
+      body: JSON.stringify({
+        query: search,
+        names: janijim.map((j) => j.nombre),
+      }),
       signal: controller.signal,
     })
       .then((res) => res.json())
@@ -91,7 +109,10 @@ export default function AsistenciaPage() {
 
     const aiMatches = aiResults
       .map((name) => janijim.find((j) => j.nombre === name))
-      .filter((j): j is { id: string; nombre: string } => !!j && !exact.some((e) => e.id === j.id))
+      .filter(
+        (j): j is { id: string; nombre: string } =>
+          !!j && !exact.some((e) => e.id === j.id),
+      )
       .map((j) => ({ ...j, ai: true }));
 
     return [...exact, ...aiMatches];
@@ -103,18 +124,80 @@ export default function AsistenciaPage() {
     scrollTo(id);
   };
 
+  useEffect(() => {
+    if (!sesionId) return;
+
+    const attendance = supabase
+      .channel("asistencias")
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "asistencias",
+          filter: `sesion_id=eq.${sesionId}`,
+        },
+        (payload) => {
+          const data = payload.new as AsistenciaRow;
+          setEstado((p) => ({ ...p, [data.janij_id]: data.presente }));
+          if (data.madrij_id !== user?.id) {
+            setUpdating(true);
+            setTimeout(() => setUpdating(false), 300);
+          }
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "asistencias",
+          filter: `sesion_id=eq.${sesionId}`,
+        },
+        (payload) => {
+          const data = payload.new as AsistenciaRow;
+          setEstado((p) => ({ ...p, [data.janij_id]: data.presente }));
+          if (data.madrij_id !== user?.id) {
+            setUpdating(true);
+            setTimeout(() => setUpdating(false), 300);
+          }
+        },
+      )
+      .subscribe();
+
+    const sesionChan = supabase
+      .channel("asistencia_sesiones")
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "asistencia_sesiones",
+          filter: `id=eq.${sesionId}`,
+        },
+        (payload) => {
+          const data = payload.new as SesionRow;
+          if (data.finalizado) {
+            setUpdating(true);
+            setFinalizado(true);
+            setTimeout(() => setUpdating(false), 300);
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(attendance);
+      supabase.removeChannel(sesionChan);
+    };
+  }, [sesionId, user?.id]);
+
   const toggle = async (janijId: string) => {
     if (!user || !sesionId) return;
     const nuevo = !estado[janijId];
     setEstado((p) => ({ ...p, [janijId]: nuevo }));
     try {
-      await marcarAsistencia(
-        sesionId,
-        proyectoId,
-        janijId,
-        user.id,
-        nuevo
-      );
+      await marcarAsistencia(sesionId, proyectoId, janijId, user.id, nuevo);
     } catch (e) {
       console.error(e);
     }
@@ -138,10 +221,8 @@ export default function AsistenciaPage() {
     const ausentes = janijim.filter((j) => !estado[j.id]);
 
     const exportar = () => {
-      const data = janijim.map((j) => ({
-        nombre: j.nombre,
-        presente: estado[j.id] ? "Si" : "No",
-      }));
+      const presentes = janijim.filter((j) => estado[j.id]);
+      const data = presentes.map((j) => ({ nombre: j.nombre }));
       const ws = XLSX.utils.json_to_sheet(data);
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, "Asistencia");
@@ -156,17 +237,20 @@ export default function AsistenciaPage() {
 
     return (
       <div className="max-w-2xl mx-auto mt-12 space-y-4">
-        <h2 className="text-xl font-semibold">Resumen de {sesion?.nombre}</h2>
+        <h2 className="text-xl font-semibold">Asistencia finalizada</h2>
+        <p className="text-gray-700">{sesion?.nombre}</p>
         <div className="bg-white p-4 rounded shadow">
           <p>Presentes: {presentes.length}</p>
           <p>Ausentes: {ausentes.length}</p>
         </div>
-        <button
-          onClick={exportar}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg w-full"
-        >
-          Descargar Excel
-        </button>
+        {esCreador && (
+          <button
+            onClick={exportar}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg w-full"
+          >
+            Descargar Excel
+          </button>
+        )}
         <button
           onClick={() => router.push(`/proyecto/${proyectoId}/janijim`)}
           className="px-4 py-2 bg-green-600 text-white rounded-lg w-full"
@@ -178,92 +262,105 @@ export default function AsistenciaPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto mt-12 space-y-4">
-      <h2 className="text-xl font-semibold">{sesion?.nombre}</h2>
-      <div className="relative flex items-center gap-2">
-        <input
-          type="text"
-          value={search}
-          onFocus={() => setShowResults(true)}
-          onBlur={() => setTimeout(() => setShowResults(false), 100)}
-          onChange={(e) => {
-            setSearch(e.target.value);
-            setShowResults(true);
-          }}
-          placeholder="Buscar janij..."
-          className="w-full border rounded-lg p-2"
-        />
+    <div className="relative">
+      {updating && (
+        <div className="absolute inset-0 bg-white/70 flex items-center justify-center z-10">
+          <Loader className="h-6 w-6" />
+        </div>
+      )}
+      <div className="max-w-2xl mx-auto mt-12 space-y-4">
+        <h2 className="text-xl font-semibold">{sesion?.nombre}</h2>
+        <div className="relative flex items-center gap-2">
+          <input
+            type="text"
+            value={search}
+            onFocus={() => setShowResults(true)}
+            onBlur={() => setTimeout(() => setShowResults(false), 100)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setShowResults(true);
+            }}
+            placeholder="Buscar janij..."
+            className="w-full border rounded-lg p-2"
+          />
 
-        {showResults && search.trim() !== "" && (
-          <ul className="absolute z-10 left-0 top-full mt-1 w-full bg-white border rounded shadow max-h-60 overflow-auto">
-            {resultados.filter((r) => !r.ai).map((r) => (
-              <li
-                key={r.id}
-                onMouseDown={() => seleccionar(r.id)}
-                className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
-              >
-                <span>{r.nombre}</span>
-              </li>
-            ))}
-            {aiLoading && (
-              <li className="p-2 text-sm text-gray-500">Buscando con IA...</li>
-            )}
-            {!aiLoading && aiResults.length === 0 && (
-              <li className="p-2 text-sm text-gray-500">
-                No se encontraron resultados con la IA.
-              </li>
-            )}
-            {!aiLoading && resultados.filter((r) => r.ai).length > 0 && (
-              <>
-                <li className="px-2 text-xs text-gray-400">Sugerencias con IA</li>
-                {resultados
-                  .filter((r) => r.ai)
-                  .map((r) => (
-                    <li
-                      key={r.id}
-                      onMouseDown={() => seleccionar(r.id)}
-                      className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
-                    >
-                      <span>{r.nombre}</span>
-                      <span className="bg-fuchsia-100 text-fuchsia-700 text-xs px-1 rounded">
-                        IA
-                      </span>
-                    </li>
-                  ))}
-              </>
-            )}
-          </ul>
+          {showResults && search.trim() !== "" && (
+            <ul className="absolute z-10 left-0 top-full mt-1 w-full bg-white border rounded shadow max-h-60 overflow-auto">
+              {resultados
+                .filter((r) => !r.ai)
+                .map((r) => (
+                  <li
+                    key={r.id}
+                    onMouseDown={() => seleccionar(r.id)}
+                    className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
+                  >
+                    <span>{r.nombre}</span>
+                  </li>
+                ))}
+              {aiLoading && (
+                <li className="p-2 text-sm text-gray-500">
+                  Buscando con IA...
+                </li>
+              )}
+              {!aiLoading && aiResults.length === 0 && (
+                <li className="p-2 text-sm text-gray-500">
+                  No se encontraron resultados con la IA.
+                </li>
+              )}
+              {!aiLoading && resultados.filter((r) => r.ai).length > 0 && (
+                <>
+                  <li className="px-2 text-xs text-gray-400">
+                    Sugerencias con IA
+                  </li>
+                  {resultados
+                    .filter((r) => r.ai)
+                    .map((r) => (
+                      <li
+                        key={r.id}
+                        onMouseDown={() => seleccionar(r.id)}
+                        className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
+                      >
+                        <span>{r.nombre}</span>
+                        <span className="bg-fuchsia-100 text-fuchsia-700 text-xs px-1 rounded">
+                          IA
+                        </span>
+                      </li>
+                    ))}
+                </>
+              )}
+            </ul>
+          )}
+        </div>
+        <ul className="space-y-2">
+          {janijim.map((j) => (
+            <li
+              id={`janij-${j.id}`}
+              key={j.id}
+              className={`flex items-center justify-between bg-white shadow p-4 rounded-lg ${
+                highlightId === j.id ? "ring-2 ring-blue-500 animate-pulse" : ""
+              }`}
+            >
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={!!estado[j.id]}
+                  onChange={() => toggle(j.id)}
+                />
+                <span>{j.nombre}</span>
+              </label>
+            </li>
+          ))}
+        </ul>
+        {esCreador && (
+          <button
+            onClick={finalizar}
+            className="px-4 py-2 bg-green-600 text-white rounded-lg w-full"
+          >
+            Finalizar asistencia
+          </button>
         )}
       </div>
-      <ul className="space-y-2">
-        {janijim.map((j) => (
-          <li
-            id={`janij-${j.id}`}
-            key={j.id}
-            className={`flex items-center justify-between bg-white shadow p-4 rounded-lg ${
-              highlightId === j.id
-                ? "ring-2 ring-blue-500 animate-pulse"
-                : ""
-            }`}
-          >
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                className="h-4 w-4"
-                checked={!!estado[j.id]}
-                onChange={() => toggle(j.id)}
-              />
-              <span>{j.nombre}</span>
-            </label>
-          </li>
-        ))}
-      </ul>
-      <button
-        onClick={finalizar}
-        className="px-4 py-2 bg-green-600 text-white rounded-lg w-full"
-      >
-        Finalizar asistencia
-      </button>
     </div>
   );
 }

--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/sheet";
 import { FileUp, EllipsisVertical } from "lucide-react";
 import Loader from "@/components/ui/loader";
+import ActiveSesionCard from "@/components/active-sesion-card";
 import {
   getJanijim,
   addJanijim,
@@ -308,6 +309,7 @@ export default function JanijimPage() {
 
   return (
     <div className="max-w-2xl mx-auto mt-12 space-y-4">
+      <ActiveSesionCard proyectoId={proyectoId} />
       <button
         onClick={() => setSesionOpen(true)}
         className="px-4 py-2 bg-blue-600 text-white rounded"

--- a/src/app/proyecto/[id]/page.tsx
+++ b/src/app/proyecto/[id]/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { getMadrijimPorProyecto } from "@/lib/supabase/madrijim-server";
+import ActiveSesionCard from "@/components/active-sesion-card";
 
 
 // ✅ Tipo correcto para páginas dinámicas
@@ -56,6 +57,7 @@ export default async function ProyectoHome({ params }: PageProps) {
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-3xl font-bold">{proyecto.nombre}</h1>
+      <ActiveSesionCard proyectoId={proyectoId} />
       <p className="text-gray-600">
         ¡Estás dentro de este proyecto! Compartí el siguiente código con otros madrijim para que se unan:
       </p>

--- a/src/components/active-sesion-card.tsx
+++ b/src/components/active-sesion-card.tsx
@@ -1,0 +1,123 @@
+"use client";
+import { useEffect, useState, useRef } from "react";
+import Link from "next/link";
+import { supabase } from "@/lib/supabase";
+import { getSesionActiva } from "@/lib/supabase/asistencias";
+import { getMadrijNombre } from "@/lib/supabase/madrijim";
+
+type SesionData = {
+  id: string;
+  nombre: string;
+  inicio: string;
+  madrij_id: string;
+  finalizado: boolean;
+};
+
+export default function ActiveSesionCard({
+  proyectoId,
+}: {
+  proyectoId: string;
+}) {
+  const [sesion, setSesion] = useState<SesionData | null>(null);
+  const [madrijNombre, setMadrijNombre] = useState<string>("");
+  const [ago, setAgo] = useState("");
+  const currentId = useRef<string | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+    const load = async () => {
+      try {
+        const s = await getSesionActiva(proyectoId);
+        if (s && !ignore) {
+          currentId.current = s.id;
+          setSesion(s as SesionData);
+          getMadrijNombre(s.madrij_id)
+            .then((n) => !ignore && setMadrijNombre(n))
+            .catch(() => {});
+        }
+      } catch {
+        /* empty */
+      }
+    };
+    load();
+
+    const channel = supabase
+      .channel("asistencia_sesiones")
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "asistencia_sesiones",
+          filter: `proyecto_id=eq.${proyectoId}`,
+        },
+        (payload) => {
+          const data = payload.new as SesionData;
+          if (!data.finalizado) {
+            currentId.current = data.id;
+            setSesion(data);
+            getMadrijNombre(data.madrij_id)
+              .then((n) => setMadrijNombre(n))
+              .catch(() => {});
+          }
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "asistencia_sesiones",
+          filter: `proyecto_id=eq.${proyectoId}`,
+        },
+        (payload) => {
+          const data = payload.new as SesionData;
+          if (data.finalizado) {
+            if (currentId.current === data.id) {
+              setSesion(null);
+              currentId.current = null;
+            }
+          } else {
+            currentId.current = data.id;
+            setSesion(data);
+            getMadrijNombre(data.madrij_id)
+              .then((n) => setMadrijNombre(n))
+              .catch(() => {});
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      ignore = true;
+      supabase.removeChannel(channel);
+    };
+  }, [proyectoId]);
+
+  useEffect(() => {
+    if (!sesion) return;
+    const calc = () => {
+      const mins = Math.floor(
+        (Date.now() - new Date(sesion.inicio).getTime()) / 60000,
+      );
+      setAgo(mins < 1 ? "hace menos de un minuto" : `hace ${mins} min`);
+    };
+    calc();
+    const id = setInterval(calc, 60000);
+    return () => clearInterval(id);
+  }, [sesion]);
+
+  if (!sesion) return null;
+
+  return (
+    <Link
+      href={`/proyecto/${proyectoId}/janijim/asistencia?sesion=${sesion.id}`}
+      className="block p-4 bg-yellow-100 border rounded-lg"
+    >
+      <p className="font-semibold">Asistencia en curso</p>
+      <p className="text-sm">
+        Iniciada por {madrijNombre || ""} {ago}
+      </p>
+    </Link>
+  );
+}

--- a/src/lib/supabase/asistencias.ts
+++ b/src/lib/supabase/asistencias.ts
@@ -31,9 +31,11 @@ export async function getSesionActiva(proyectoId: string) {
     .select("*")
     .eq("proyecto_id", proyectoId)
     .eq("finalizado", false)
-    .single();
-  if (error && error.code !== "PGRST116") throw error;
-  return data;
+    .order("inicio", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data || null;
 }
 
 export async function finalizarSesion(id: string) {

--- a/src/lib/supabase/madrijim.ts
+++ b/src/lib/supabase/madrijim.ts
@@ -16,3 +16,13 @@ export async function getMadrijimPorProyecto(proyectoId: string) {
   if (e2) throw e2;
   return madrijim;
 }
+
+export async function getMadrijNombre(clerkId: string) {
+  const { data, error } = await supabase
+    .from("madrijim")
+    .select("nombre")
+    .eq("clerk_id", clerkId)
+    .single();
+  if (error) throw error;
+  return data.nombre as string;
+}


### PR DESCRIPTION
## Summary
- add helper to fetch madrij name
- show live attendance notice on project home and janijim pages
- implement `ActiveSesionCard` component
- add real-time syncing in attendance page with overlay loader
- limit finishing/exporting session to its creator and export only present names
- fix active session detection
- update card to refresh elapsed time and clarify finished message
- improve real-time attendance updates
- fix realtime subscriptions
- format attendance files

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a0e7d017c83319224d5d5be6b223e