### PR TITLE
Ensure mobile menu closes after navigation

### DIFF
--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -6,6 +6,7 @@ import {
   SheetTrigger,
   SheetTitle,
   SheetDescription,
+  SheetClose,
 } from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
 import Link from "next/link";
@@ -52,16 +53,17 @@ export default function MobileMenu({ proyectoId }: MobileMenuProps) {
               const isActive = pathname === fullPath || pathname === fullPath + "/";
 
               return (
-                <Link
-                  key={href}
-                  href={fullPath}
-                  className={cn(
-                    "block text-base font-medium",
-                    isActive ? "text-blue-700" : "text-gray-700"
-                  )}
-                >
-                  {label}
-                </Link>
+                <SheetClose asChild key={href}>
+                  <Link
+                    href={fullPath}
+                    className={cn(
+                      "block text-base font-medium",
+                      isActive ? "text-blue-700" : "text-gray-700"
+                    )}
+                  >
+                    {label}
+                  </Link>
+                </SheetClose>
               );
             })}
           </nav>


### PR DESCRIPTION
## Summary
- ensure MobileMenu links close the drawer when clicked

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ae30f18dc8331a3c2e9c1f7363d9b