### PR TITLE
Add dashboard link to menus

### DIFF
--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -17,6 +17,7 @@ type MobileMenuProps = {
 };
 
 const links = [
+  { href: "/dashboard", label: "Mis Proyectos" },
   { href: "", label: "Inicio" },
   { href: "janijim", label: "Janijim" },
   { href: "notas", label: "Notas" },
@@ -46,7 +47,9 @@ export default function MobileMenu({ proyectoId }: MobileMenuProps) {
 
           <nav className="space-y-4 mt-6">
             {links.map(({ href, label }) => {
-              const fullPath = href
+              const fullPath = href.startsWith("/")
+                ? href
+                : href
                 ? `/proyecto/${proyectoId}/${href}`
                 : `/proyecto/${proyectoId}`;
               const isActive = pathname === fullPath || pathname === fullPath + "/";

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -11,10 +11,12 @@ import {
   PencilRuler,
   PartyPopper,
   Bot,
-  Home
+  Home,
+  LayoutDashboard,
 } from "lucide-react";
 
 const links = [
+  { href: "/dashboard", label: "Mis Proyectos", icon: LayoutDashboard },
   { href: "", label: "Inicio", icon: Home },
   { href: "janijim", label: "Janijim", icon: ClipboardList },
   { href: "notas", label: "Notas", icon: Book },
@@ -32,7 +34,9 @@ export default function Sidebar({ proyectoId }: { proyectoId: string }) {
     <aside className="hidden md:block w-64 bg-white border-r p-4">
       <nav className="space-y-2">
         {links.map(({ href, label, icon: Icon }) => {
-          const fullPath = href
+          const fullPath = href.startsWith("/")
+            ? href
+            : href
             ? `/proyecto/${proyectoId}/${href}`
             : `/proyecto/${proyectoId}`;
           const isActive = pathname === fullPath || pathname === fullPath + "/";


### PR DESCRIPTION
## Summary
- let users return to project list easily
- include "Mis Proyectos" entry in sidebar and mobile menu

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ae31616e883318b6f55ecadbd9ec3