### PR TITLE
Add user button to project layout

### DIFF
--- a/src/app/proyecto/[id]/layout.tsx
+++ b/src/app/proyecto/[id]/layout.tsx
@@ -1,5 +1,6 @@
 import Sidebar from "@/components/ui/sidebar";
 import MobileMenu from "@/components/ui/mobile-menu";
+import { UserButton } from "@clerk/nextjs";
 
 export default async function ProyectoLayout({
   children,
@@ -13,8 +14,11 @@ export default async function ProyectoLayout({
   return (
     <div className="min-h-screen md:flex">
       <Sidebar proyectoId={proyectoId} />
-      <div className="flex-1">
+      <div className="flex-1 flex flex-col">
         <MobileMenu proyectoId={proyectoId} />
+        <header className="p-4 border-b flex justify-end">
+          <UserButton afterSignOutUrl="/" />
+        </header>
         <main className="p-6">{children}</main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replicate account menu in project layout so users can sign out

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ae317451c833187e967fadfec1f6e