### PR TITLE
Add not-found pages for main routes

### DIFF
--- a/src/app/dashboard/not-found.tsx
+++ b/src/app/dashboard/not-found.tsx
@@ -1,0 +1,13 @@
+import { AlertCircle } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="max-w-xl mx-auto mt-24 text-center bg-white p-8 rounded-2xl shadow-md">
+      <div className="flex justify-center mb-4 text-red-600">
+        <AlertCircle size={48} />
+      </div>
+      <h1 className="text-3xl font-semibold text-red-700 mb-2">No se encontró el dashboard</h1>
+      <p className="text-gray-600">El recurso solicitado no está disponible.</p>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import { AlertCircle } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="max-w-xl mx-auto mt-24 text-center bg-white p-8 rounded-2xl shadow-md">
+      <div className="flex justify-center mb-4 text-red-600">
+        <AlertCircle size={48} />
+      </div>
+      <h1 className="text-3xl font-semibold text-red-700 mb-2">Página no encontrada</h1>
+      <p className="text-gray-600">La página que buscás no existe.</p>
+    </div>
+  );
+}

--- a/src/app/proyecto/[id]/not-found.tsx
+++ b/src/app/proyecto/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import { AlertCircle } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="max-w-xl mx-auto mt-24 text-center bg-white p-8 rounded-2xl shadow-md">
+      <div className="flex justify-center mb-4 text-red-600">
+        <AlertCircle size={48} />
+      </div>
+      <h1 className="text-3xl font-semibold text-red-700 mb-2">Proyecto no encontrado</h1>
+      <p className="text-gray-600">El proyecto que buscás no existe o no está disponible.</p>
+    </div>
+  );
+}

--- a/src/app/proyecto/[id]/page.tsx
+++ b/src/app/proyecto/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { getMadrijimPorProyecto } from "@/lib/supabase/madrijim-server";
 import ActiveSesionCard from "@/components/active-sesion-card";
@@ -49,7 +49,7 @@ export default async function ProyectoHome({ params }: PageProps) {
 
   if (!proyecto || errorProyecto) {
     console.error("Error cargando el proyecto", errorProyecto);
-    return <div className="p-6">Error cargando el proyecto</div>;
+    notFound();
   }
 
   const madrijim = await getMadrijimPorProyecto(proyectoId);


### PR DESCRIPTION
## Summary
- handle missing project with `notFound()`
- add custom `not-found.tsx` pages for app root, dashboard and proyecto routes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ae317bb108331833c6ce7c62cc257