### PR TITLE
Use toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next": "^15.2.3",
         "react": "^19.1.0",
         "react-dom": "^19.0.0",
+        "react-hot-toast": "^2.4.1",
         "tailwind-merge": "^3.3.0",
         "tailwind-variants": "^1.0.0",
         "xlsx": "^0.18.5"
@@ -3867,6 +3868,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5409,6 +5419,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "^15.2.3",
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.4.1",
     "tailwind-merge": "^3.3.0",
     "tailwind-variants": "^1.0.0",
     "xlsx": "^0.18.5"

--- a/src/app/dashboard/nuevo/page.tsx
+++ b/src/app/dashboard/nuevo/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "react-hot-toast";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
@@ -24,7 +25,10 @@ export default function NuevoProyectoPage() {
       .select()
       .single();
 
-    if (e1) return alert("Error creando proyecto");
+    if (e1) {
+      toast.error("Error creando proyecto");
+      return;
+    }
 
     // 2. Insertar relación con madrijim_proyectos
     const { error: e2 } = await supabase
@@ -32,7 +36,7 @@ export default function NuevoProyectoPage() {
       .insert({ proyecto_id: proyecto.id, madrij_id: user.id, rol: "creador", invitado: false });
 
     if (e2) {
-      alert("Error asignando proyecto");
+      toast.error("Error asignando proyecto");
       setCreating(false);
       return;
     }

--- a/src/app/dashboard/unirse/page.tsx
+++ b/src/app/dashboard/unirse/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "react-hot-toast";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
@@ -22,7 +23,7 @@ export default function UnirseProyectoPage() {
       .single();
 
     if (!proyecto || error) {
-      alert("Código inválido");
+      toast.error("Código inválido");
       setLoading(false);
       return;
     }
@@ -32,7 +33,7 @@ export default function UnirseProyectoPage() {
       .insert({ proyecto_id: proyecto.id, madrij_id: user.id, invitado: false });
 
     if (e2 && e2.code !== "23505") {
-      alert("Error uniéndose al proyecto");
+      toast.error("Error uniéndose al proyecto");
       setLoading(false);
       return;
     }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
 import ClientBootstrap from "@/components/client-bootstrap";
+import ToastProvider from "@/components/ui/toaster";
 // Using system fonts avoids downloading external font files during the build
 // process, which can fail in restricted environments.
 
@@ -16,6 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <html lang="es">
         <body className="antialiased bg-gray-50 text-gray-800">
           <ClientBootstrap />
+          <ToastProvider />
           {children}
         </body>
       </html>

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Toaster } from "react-hot-toast";
+
+export default function ToastProvider() {
+  return (
+    <Toaster
+      position="top-right"
+      toastOptions={{
+        className:
+          "bg-white text-gray-800 shadow-lg border border-gray-200 rounded-md",
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `react-hot-toast` dependency
- implement a `ToastProvider` component
- show a global `<ToastProvider />` in layout
- surface Nuevo and Unirse errors using toast notifications

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ae3192e588331a84e39ca35c66254