### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -337,8 +337,16 @@ export default function JanijimPage() {
     {resultados.filter((r) => !r.ai).map((r) => (
       <li
         key={r.id}
+        tabIndex={0}
         onMouseDown={() => seleccionar(r.id)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            seleccionar(r.id);
+          }
+        }}
         className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
+        aria-label={`Seleccionar ${r.nombre}`}
       >
         <span>{r.nombre}</span>
       </li>
@@ -365,8 +373,16 @@ export default function JanijimPage() {
           .map((r) => (
             <li
               key={r.id}
+              tabIndex={0}
               onMouseDown={() => seleccionar(r.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  seleccionar(r.id);
+                }
+              }}
               className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
+              aria-label={`Seleccionar ${r.nombre}`}
             >
               <span>{r.nombre}</span>
               <span className="bg-fuchsia-100 text-fuchsia-700 text-xs px-1 rounded">
@@ -386,8 +402,16 @@ export default function JanijimPage() {
         (r) => r.nombre.toLowerCase() === search.trim().toLowerCase()
       ) && (
         <li
+          tabIndex={0}
           onMouseDown={() => agregar(search.trim())}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              agregar(search.trim());
+            }
+          }}
           className="p-2 cursor-pointer hover:bg-gray-100"
+          aria-label={`Agregar ${search.trim()}`}
         >
           Agregar &quot;{search.trim()}&quot;
         </li>
@@ -425,14 +449,29 @@ export default function JanijimPage() {
             <span>{janij.nombre}</span>
             <div className="relative">
               <button
+                aria-label="Opciones"
+                aria-haspopup="menu"
+                aria-expanded={menuOpenId === janij.id}
                 onClick={() =>
                   setMenuOpenId(menuOpenId === janij.id ? null : janij.id)
                 }
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setMenuOpenId(menuOpenId === janij.id ? null : janij.id);
+                  }
+                  if (e.key === "Escape") {
+                    setMenuOpenId(null);
+                  }
+                }}
               >
                 <EllipsisVertical size={16} />
               </button>
               {menuOpenId === janij.id && (
-                <div className="absolute right-0 mt-2 bg-white border rounded shadow z-10">
+                <div
+                  className="absolute right-0 mt-2 bg-white border rounded shadow z-10"
+                  onKeyDown={(e) => e.key === "Escape" && setMenuOpenId(null)}
+                >
                   <button
                     onClick={() => {
                       setMenuOpenId(null);

--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -33,7 +33,7 @@ export default function MobileMenu({ proyectoId }: MobileMenuProps) {
   return (
     <div className="md:hidden p-4 bg-white shadow-md flex items-center">
       <Sheet>
-        <SheetTrigger>
+        <SheetTrigger aria-label="Abrir men\u00fa de navegaci\u00f3n">
           <Menu className="text-blue-700" />
         </SheetTrigger>
         <SheetContent side="left" className="w-64 p-4">


### PR DESCRIPTION
## Summary
- add ARIA label to mobile menu trigger
- make search suggestion items keyboard accessible
- allow opening options menu with keyboard and close on Escape

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ae31acd6083318c585c2fb99001e6