### PR TITLE
Add back link to join project page

### DIFF
--- a/src/app/dashboard/unirse/page.tsx
+++ b/src/app/dashboard/unirse/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import Loader from "@/components/ui/loader";
 
@@ -43,6 +44,12 @@ export default function UnirseProyectoPage() {
 
   return (
     <div>
+      <Link
+        href="/dashboard"
+        className="text-blue-600 hover:underline mb-4 inline-block"
+      >
+        &larr; Volver
+      </Link>
       <h1 className="text-2xl font-bold mb-4">Unirse a un Proyecto</h1>
       <input
         type="text"


### PR DESCRIPTION
## Summary
- allow navigation back to dashboard from join project screen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684aef229794833182e3f2bf026014f2