### PR TITLE
Unify sign‑in and sign‑up flow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SignInButton, SignUpButton, useAuth } from "@clerk/nextjs";
+import { SignInButton, useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
@@ -20,16 +20,16 @@ export default function HomePage() {
       <h1 className="text-4xl font-bold mb-4">Bienvenido a MadrijApp</h1>
       <p className="text-lg text-gray-600 mb-6">Tu espacio para organizar todo como madrij.</p>
       <div className="flex gap-4">
-        <SignInButton mode="redirect" forceRedirectUrl="/dashboard">
+        <SignInButton
+          mode="modal"
+          withSignUp
+          afterSignInUrl="/dashboard"
+          afterSignUpUrl="/dashboard"
+        >
           <button className="px-4 py-2 bg-black text-white rounded-xl hover:bg-gray-900 transition">
             Iniciar sesión
           </button>
         </SignInButton>
-        <SignUpButton mode="redirect" forceRedirectUrl="/dashboard">
-          <button className="px-4 py-2 bg-gray-200 text-black rounded-xl hover:bg-gray-300 transition">
-            Crear cuenta
-          </button>
-        </SignUpButton>
       </div>
     </main>
   );

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <SignIn withSignUp afterSignInUrl="/dashboard" afterSignUpUrl="/dashboard" />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- update the landing page to only show a single sign-in button
- open a modal that can create an account automatically when the email is not registered
- add custom `/sign-in` page using Clerk's new `withSignUp` option

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af2167a8c83318ff9bdc7baf966e0