### PR TITLE
Fix Clerk sign-in props

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,8 +23,8 @@ export default function HomePage() {
         <SignInButton
           mode="modal"
           withSignUp
-          afterSignInUrl="/dashboard"
-          afterSignUpUrl="/dashboard"
+          forceRedirectUrl="/dashboard"
+          signUpForceRedirectUrl="/dashboard"
         >
           <button className="px-4 py-2 bg-black text-white rounded-xl hover:bg-gray-900 transition">
             Iniciar sesión

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,7 @@ import { SignIn } from "@clerk/nextjs";
 export default function SignInPage() {
   return (
     <main className="flex min-h-screen items-center justify-center">
-      <SignIn withSignUp afterSignInUrl="/dashboard" afterSignUpUrl="/dashboard" />
+      <SignIn withSignUp forceRedirectUrl="/dashboard" signUpForceRedirectUrl="/dashboard" />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- update `SignInButton` props to use `forceRedirectUrl`
- update sign-in page to use `forceRedirectUrl`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684af50c279483319fa80e8610c6a933