### PR TITLE
Improve attendance session creation

### DIFF
--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -66,9 +66,6 @@ export default function JanijimPage() {
   const [editName, setEditName] = useState("");
   const [sesionOpen, setSesionOpen] = useState(false);
   const [sesionNombre, setSesionNombre] = useState("");
-  const [sesionFecha, setSesionFecha] = useState(
-    new Date().toISOString().slice(0, 16)
-  );
   const [madrijes, setMadrijes] = useState<{ clerk_id: string; nombre: string }[]>([]);
   const [sesionMadrij, setSesionMadrij] = useState<string>("");
   const pendingScrollId = useRef<string | null>(null);
@@ -279,11 +276,16 @@ export default function JanijimPage() {
   const iniciarSesion = async () => {
     if (!user) return;
     try {
+      const ahora = new Date();
+      const rounded = new Date(Math.ceil(ahora.getTime() / (15 * 60 * 1000)) * (15 * 60 * 1000));
+      const inicioIso = rounded.toISOString();
+      const fecha = inicioIso.split("T")[0];
       const sesion = await crearSesion(
         proyectoId,
         sesionNombre || "Asistencia",
-        sesionFecha.split("T")[0],
-        sesionMadrij || user.id
+        fecha,
+        sesionMadrij || user.id,
+        inicioIso
       );
       router.push(
         `/proyecto/${proyectoId}/janijim/asistencia?sesion=${sesion.id}`
@@ -729,7 +731,7 @@ export default function JanijimPage() {
           <SheetHeader>
             <SheetTitle>Nueva toma de asistencia</SheetTitle>
             <SheetDescription>
-              Ingresá el nombre, fecha y madrij encargado.
+              Ingresá el nombre y quién la lleva a cabo.
             </SheetDescription>
           </SheetHeader>
           <div className="p-4 space-y-4">
@@ -738,13 +740,6 @@ export default function JanijimPage() {
               value={sesionNombre}
               onChange={(e) => setSesionNombre(e.target.value)}
               placeholder="Nombre de la sesión"
-              className="w-full border rounded-lg p-2"
-            />
-            <input
-              type="datetime-local"
-              value={sesionFecha}
-              onChange={(e) => setSesionFecha(e.target.value)}
-              placeholder="Fecha y hora de inicio"
               className="w-full border rounded-lg p-2"
             />
             <select

--- a/src/lib/supabase/asistencias.ts
+++ b/src/lib/supabase/asistencias.ts
@@ -4,11 +4,18 @@ export async function crearSesion(
   proyectoId: string,
   nombre: string,
   fecha: string,
-  madrijId: string
+  madrijId: string,
+  inicio: string
 ) {
   const { data, error } = await supabase
     .from("asistencia_sesiones")
-    .insert({ proyecto_id: proyectoId, nombre, fecha, madrij_id: madrijId })
+    .insert({
+      proyecto_id: proyectoId,
+      nombre,
+      fecha,
+      madrij_id: madrijId,
+      inicio,
+    })
     .select()
     .single();
   if (error) throw error;


### PR DESCRIPTION
## Summary
- auto-set attendance session start time rounded to the next 15 minutes
- remove datetime field from new session sheet
- update Supabase helper to accept explicit start time

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b013230608331994e961fcbea7c62