### PR TITLE
Add Materiales board page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.20.1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@radix-ui/react-dialog": "^1.1.14",
         "@supabase/supabase-js": "^2.49.8",
         "class-variance-authority": "^0.7.1",
@@ -157,6 +159,59 @@
       },
       "engines": {
         "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.20.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@radix-ui/react-dialog": "^1.1.14",
     "@supabase/supabase-js": "^2.49.8",
     "class-variance-authority": "^0.7.1",

--- a/src/app/proyecto/[id]/materiales/page.tsx
+++ b/src/app/proyecto/[id]/materiales/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+
+interface Material {
+  id: string;
+  nombre: string;
+  estado: Estado;
+}
+
+type Estado = "por-hacer" | "en-proceso" | "realizado";
+
+const estados: { id: Estado; titulo: string }[] = [
+  { id: "por-hacer", titulo: "Por hacer" },
+  { id: "en-proceso", titulo: "En proceso" },
+  { id: "realizado", titulo: "Realizado" },
+];
+
+function MaterialCard({ material }: { material: Material }) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useDraggable({ id: material.id });
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className="bg-white p-3 rounded shadow mb-2 cursor-grab"
+    >
+      {material.nombre}
+    </div>
+  );
+}
+
+function Column({ estado, children }: { estado: Estado; children: React.ReactNode }) {
+  const { setNodeRef } = useDroppable({ id: estado });
+  return (
+    <div
+      ref={setNodeRef}
+      className="flex-1 bg-gray-100 rounded p-2 min-h-[200px]"
+    >
+      {children}
+    </div>
+  );
+}
+
+export default function MaterialesPage() {
+  const [materials, setMaterials] = useState<Material[]>([
+    { id: "1", nombre: "Cartulina", estado: "por-hacer" },
+    { id: "2", nombre: "Marcadores", estado: "en-proceso" },
+    { id: "3", nombre: "Tijeras", estado: "realizado" },
+  ]);
+  const [newName, setNewName] = useState("");
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { over, active } = event;
+    if (over && over.id !== active.id) {
+      const nuevoEstado = over.id as Estado;
+      setMaterials((prev) =>
+        prev.map((m) => (m.id === active.id ? { ...m, estado: nuevoEstado } : m))
+      );
+    }
+  };
+
+  const addMaterial = () => {
+    const nombre = newName.trim();
+    if (nombre === "") return;
+    setMaterials((prev) => [
+      ...prev,
+      { id: Date.now().toString(), nombre, estado: "por-hacer" },
+    ]);
+    setNewName("");
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Materiales</h1>
+      <div className="flex gap-2">
+        <input
+          className="border p-2 flex-1 rounded"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="Nuevo material"
+        />
+        <button
+          onClick={addMaterial}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Agregar
+        </button>
+      </div>
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <div className="flex gap-4">
+          {estados.map(({ id, titulo }) => (
+            <Column key={id} estado={id}>
+              <h2 className="font-semibold mb-2 text-center">{titulo}</h2>
+              {materials
+                .filter((m) => m.estado === id)
+                .map((m) => (
+                  <MaterialCard key={m.id} material={m} />
+                ))}
+            </Column>
+          ))}
+        </div>
+      </DndContext>
+    </div>
+  );
+}
+

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   CheckSquare,
   PencilRuler,
   PartyPopper,
+  Boxes,
   Bot,
   Home,
   LayoutDashboard,
@@ -25,6 +26,7 @@ const links = [
   { href: "tareas", label: "Tareas", icon: CheckSquare },
   { href: "planificaciones", label: "Planificaciones", icon: PencilRuler },
   { href: "actividades", label: "Actividades", icon: PartyPopper },
+  { href: "materiales", label: "Materiales", icon: Boxes },
   { href: "chatbot", label: "Chatbot", icon: Bot },
 ];
 


### PR DESCRIPTION
## Summary
- add Materiales board page under /proyecto/[id]/materiales
- enable drag and drop with dnd-kit
- add Materiales link to sidebar
- install dnd-kit packages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b6cbd62ec83318d7a20acd46a54df