### PR TITLE
Improve material list UI

### DIFF
--- a/src/app/proyecto/[id]/materiales/[list]/page.tsx
+++ b/src/app/proyecto/[id]/materiales/[list]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useParams } from "next/navigation";
-import { FolderKanban, ShoppingCart, Building2, Tent, Trash2 } from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import { FolderKanban, ShoppingCart, Building2, Tent, Trash2, Plus } from "lucide-react";
 import Button from "@/components/ui/button";
 import {
   Sheet,
@@ -17,6 +17,7 @@ import {
   addMaterialEnLista,
   updateMaterial,
   deleteMaterial,
+  deleteMaterialList,
   MaterialRow,
 } from "@/lib/supabase/materiales";
 import { getMadrijimPorProyecto } from "@/lib/supabase/madrijim-client";
@@ -59,6 +60,7 @@ export default function MaterialesPage() {
 
 
   const { id: proyectoId, list } = useParams<{ id: string; list: string }>();
+  const router = useRouter();
   const estados: Estado[] = ["por hacer", "en proceso", "realizado"];
 
   const [materiales, setMateriales] = useState<Material[]>([]);
@@ -72,7 +74,6 @@ export default function MaterialesPage() {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [materialActual, setMaterialActual] = useState<Material | null>(null);
   const [filtroAsignado, setFiltroAsignado] = useState("");
-  const [busqueda, setBusqueda] = useState("");
 
   useEffect(() => {
     if (!proyectoId || !list) return;
@@ -159,6 +160,14 @@ export default function MaterialesPage() {
       .catch(() => alert("Error eliminando material"));
   };
 
+  const eliminarLista = () => {
+    if (!list) return;
+    if (!confirm("¿Eliminar lista?")) return;
+    deleteMaterialList(list)
+      .then(() => router.push("../"))
+      .catch(() => alert("Error eliminando lista"));
+  };
+
 
   const agregarItemLista = (
     mat: Material,
@@ -197,14 +206,9 @@ export default function MaterialesPage() {
       <h1 className="text-3xl font-bold flex items-center gap-2 text-blue-900">
         <FolderKanban className="w-7 h-7" /> organización de materiales
       </h1>
+      <Button variant="danger" onClick={eliminarLista}>Eliminar lista</Button>
 
       <div className="flex flex-col sm:flex-row gap-2">
-        <input
-          value={busqueda}
-          onChange={(e) => setBusqueda(e.target.value)}
-          placeholder="Buscar material"
-          className="border rounded p-2 flex-1"
-        />
         <select
           value={filtroAsignado}
           onChange={(e) => setFiltroAsignado(e.target.value)}
@@ -247,8 +251,7 @@ export default function MaterialesPage() {
                   .filter(
                     (m) =>
                       m.estado === estado &&
-                      (!filtroAsignado || m.asignado === filtroAsignado) &&
-                      m.nombre.toLowerCase().includes(busqueda.toLowerCase())
+                      (!filtroAsignado || m.asignado === filtroAsignado)
                   )
                   .map((m) => (
                     <div
@@ -279,8 +282,7 @@ export default function MaterialesPage() {
                 {materiales.filter(
                   (m) =>
                     m.estado === estado &&
-                    (!filtroAsignado || m.asignado === filtroAsignado) &&
-                    m.nombre.toLowerCase().includes(busqueda.toLowerCase())
+                    (!filtroAsignado || m.asignado === filtroAsignado)
                 ).length === 0 && (
                   <p className="text-sm text-gray-500">Sin materiales</p>
                 )}
@@ -387,9 +389,9 @@ export default function MaterialesPage() {
                   <Button
                     variant="secondary"
                     onClick={() => setMostrarAgregar((p) => !p)}
-                    className="mb-2"
+                    className="mb-2 flex items-center gap-1"
                   >
-                    {mostrarAgregar ? "Cancelar" : "Agregar item"}
+                    {mostrarAgregar ? "Cancelar" : <><Plus className="w-4 h-4" /> Agregar</>}
                   </Button>
                   {mostrarAgregar && (
                     <div className="flex gap-2 mt-2">

--- a/src/app/proyecto/[id]/materiales/page.tsx
+++ b/src/app/proyecto/[id]/materiales/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { getMaterialLists, addMaterialList } from "@/lib/supabase/materiales";
+import { getMaterialLists, addMaterialList, deleteMaterialList } from "@/lib/supabase/materiales";
+import { Trash2 } from "lucide-react";
 import Button from "@/components/ui/button";
 
 export default function MaterialesIndexPage() {
@@ -11,6 +12,7 @@ export default function MaterialesIndexPage() {
   const [listas, setListas] = useState<{ id: string; titulo: string; fecha: string }[]>([]);
   const [titulo, setTitulo] = useState("");
   const [fecha, setFecha] = useState("");
+  const hoy = new Date().toISOString().split("T")[0];
 
   useEffect(() => {
     if (!proyectoId) return;
@@ -30,22 +32,70 @@ export default function MaterialesIndexPage() {
       .catch(() => alert("Error creando lista"));
   };
 
+  const eliminarLista = (id: string) => {
+    if (!confirm("¿Eliminar lista?")) return;
+    deleteMaterialList(id)
+      .then(() => setListas((prev) => prev.filter((l) => l.id !== id)))
+      .catch(() => alert("Error eliminando lista"));
+  };
+
+  const listasFuturas = listas.filter((l) => l.fecha >= hoy);
+  const listasPrevias = listas.filter((l) => l.fecha < hoy);
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold text-blue-900">Listas de materiales</h1>
       {listas.length === 0 && <p className="text-gray-600">No hay listas creadas.</p>}
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {listas.map((l) => (
-          <div
-            key={l.id}
-            onClick={() => router.push(`./materiales/${l.id}`)}
-            className="cursor-pointer rounded border p-4 bg-white shadow hover:shadow-md"
-          >
-            <h3 className="font-semibold">{l.titulo}</h3>
-            <p className="text-sm text-gray-600">{l.fecha}</p>
-          </div>
-        ))}
-      </div>
+
+      <details open>
+        <summary className="font-semibold cursor-pointer mb-2">Futuras</summary>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+          {listasFuturas.map((l) => (
+            <div
+              key={l.id}
+              onClick={() => router.push(`./materiales/${l.id}`)}
+              className="cursor-pointer rounded border p-4 bg-white shadow hover:shadow-md relative group"
+            >
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  eliminarLista(l.id);
+                }}
+                className="absolute top-2 right-2 text-red-600 hover:text-red-800 hidden group-hover:block"
+              >
+                <Trash2 size={16} />
+              </button>
+              <h3 className="font-semibold">{l.titulo}</h3>
+              <p className="text-sm text-gray-600">{l.fecha}</p>
+            </div>
+          ))}
+        </div>
+      </details>
+
+      <details>
+        <summary className="font-semibold cursor-pointer mb-2">Previas</summary>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+          {listasPrevias.map((l) => (
+            <div
+              key={l.id}
+              onClick={() => router.push(`./materiales/${l.id}`)}
+              className="cursor-pointer rounded border p-4 bg-white shadow hover:shadow-md relative group"
+            >
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  eliminarLista(l.id);
+                }}
+                className="absolute top-2 right-2 text-red-600 hover:text-red-800 hidden group-hover:block"
+              >
+                <Trash2 size={16} />
+              </button>
+              <h3 className="font-semibold">{l.titulo}</h3>
+              <p className="text-sm text-gray-600">{l.fecha}</p>
+            </div>
+          ))}
+        </div>
+      </details>
       <div className="space-y-2">
         <h2 className="text-xl font-semibold text-blue-800">Crear nueva lista</h2>
         <div className="flex flex-col sm:flex-row gap-2">


### PR DESCRIPTION
## Summary
- separate future and past material lists
- allow deleting a material list from index and detail pages
- remove search filter and keep assigned filter
- tweak add-item button with plus icon

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b9bd62b308331bf4cc52b4e9b64f1