### PR TITLE
Improve materiales UI

### DIFF
--- a/src/app/proyecto/[id]/materiales/[list]/page.tsx
+++ b/src/app/proyecto/[id]/materiales/[list]/page.tsx
@@ -70,6 +70,7 @@ export default function MaterialesPage() {
   const [nuevoItemGeneral, setNuevoItemGeneral] = useState("");
   const [tipoNuevoItem, setTipoNuevoItem] = useState<"compra" | "sede" | "sanMiguel">("compra");
   const [mostrarAgregar, setMostrarAgregar] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [materialActual, setMaterialActual] = useState<Material | null>(null);
@@ -386,26 +387,51 @@ export default function MaterialesPage() {
                   placeholder="Descripción"
                 />
                 <div>
-                  <Button
-                    variant="secondary"
-                    onClick={() => setMostrarAgregar((p) => !p)}
-                    className="mb-2 flex items-center gap-1"
-                  >
-                    {mostrarAgregar ? "Cancelar" : <><Plus className="w-4 h-4" /> Agregar</>}
-                  </Button>
+                  <div className="relative mb-2">
+                    <Button
+                      variant="secondary"
+                      onClick={() => setMenuOpen((p) => !p)}
+                      className="flex items-center gap-1"
+                    >
+                      <Plus className="w-4 h-4" />
+                    </Button>
+                    {menuOpen && (
+                      <div className="absolute right-0 z-20 bg-white border rounded shadow mt-1 w-40">
+                        <button
+                          className="flex w-full items-center gap-2 p-2 hover:bg-gray-100"
+                          onClick={() => {
+                            setTipoNuevoItem("compra");
+                            setMostrarAgregar(true);
+                            setMenuOpen(false);
+                          }}
+                        >
+                          <ShoppingCart className="w-4 h-4" /> Comprar
+                        </button>
+                        <button
+                          className="flex w-full items-center gap-2 p-2 hover:bg-gray-100"
+                          onClick={() => {
+                            setTipoNuevoItem("sede");
+                            setMostrarAgregar(true);
+                            setMenuOpen(false);
+                          }}
+                        >
+                          <Building2 className="w-4 h-4" /> Retirar en sede
+                        </button>
+                        <button
+                          className="flex w-full items-center gap-2 p-2 hover:bg-gray-100"
+                          onClick={() => {
+                            setTipoNuevoItem("sanMiguel");
+                            setMostrarAgregar(true);
+                            setMenuOpen(false);
+                          }}
+                        >
+                          <Tent className="w-4 h-4" /> En San Miguel
+                        </button>
+                      </div>
+                    )}
+                  </div>
                   {mostrarAgregar && (
                     <div className="flex gap-2 mt-2">
-                      <select
-                        value={tipoNuevoItem}
-                        onChange={(e) =>
-                          setTipoNuevoItem(e.target.value as "compra" | "sede" | "sanMiguel")
-                        }
-                        className="border rounded p-1"
-                      >
-                        <option value="compra">Compra</option>
-                        <option value="sede">Retirar de sede</option>
-                        <option value="sanMiguel">En San Miguel</option>
-                      </select>
                       <input
                         value={nuevoItemGeneral}
                         onChange={(e) => setNuevoItemGeneral(e.target.value)}
@@ -426,6 +452,12 @@ export default function MaterialesPage() {
                         }}
                       >
                         Agregar
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={() => setMostrarAgregar(false)}
+                      >
+                        Cancelar
                       </Button>
                     </div>
                   )}
@@ -487,20 +519,24 @@ export default function MaterialesPage() {
                   </div>
                 </details>
 
-                <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={materialActual.armarEnSanMiguel}
-                    onChange={(e) =>
+                <div className="flex items-center gap-2 text-sm">
+                  <span>Se termina en</span>
+                  <button
+                    onClick={() =>
                       actualizarMaterial(
                         materialActual.id,
                         "armarEnSanMiguel",
-                        e.target.checked
+                        !materialActual.armarEnSanMiguel
                       )
                     }
-                  />
-                  Terminar en San Miguel
-                </label>
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${materialActual.armarEnSanMiguel ? "bg-blue-600" : "bg-gray-300"}`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${materialActual.armarEnSanMiguel ? "translate-x-6" : "translate-x-1"}`}
+                    />
+                  </button>
+                  <span>{materialActual.armarEnSanMiguel ? "San Miguel" : "Capital"}</span>
+                </div>
 
                 <label className="flex items-center gap-2">
                   <span>Asignado a:</span>

--- a/src/app/proyecto/[id]/materiales/page.tsx
+++ b/src/app/proyecto/[id]/materiales/page.tsx
@@ -39,7 +39,8 @@ export default function MaterialesIndexPage() {
       .catch(() => alert("Error eliminando lista"));
   };
 
-  const listasFuturas = listas.filter((l) => l.fecha >= hoy);
+  const bandeja = listas.filter((l) => !l.fecha || l.fecha === hoy);
+  const listasFuturas = listas.filter((l) => l.fecha > hoy);
   const listasPrevias = listas.filter((l) => l.fecha < hoy);
 
   return (
@@ -48,7 +49,32 @@ export default function MaterialesIndexPage() {
       {listas.length === 0 && <p className="text-gray-600">No hay listas creadas.</p>}
 
       <details open>
-        <summary className="font-semibold cursor-pointer mb-2">Futuras</summary>
+        <summary className="font-semibold cursor-pointer mb-2">Bandeja de entrada</summary>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+          {bandeja.map((l) => (
+            <div
+              key={l.id}
+              onClick={() => router.push(`./materiales/${l.id}`)}
+              className="cursor-pointer rounded border p-4 bg-white shadow hover:shadow-md relative group"
+            >
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  eliminarLista(l.id);
+                }}
+                className="absolute top-2 right-2 text-red-600 hover:text-red-800 hidden group-hover:block"
+              >
+                <Trash2 size={16} />
+              </button>
+              <h3 className="font-semibold">{l.titulo}</h3>
+              <p className="text-sm text-gray-600">{l.fecha}</p>
+            </div>
+          ))}
+        </div>
+      </details>
+
+      <details>
+        <summary className="font-semibold cursor-pointer mb-2">Futuras listas</summary>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
           {listasFuturas.map((l) => (
             <div
@@ -73,7 +99,7 @@ export default function MaterialesIndexPage() {
       </details>
 
       <details>
-        <summary className="font-semibold cursor-pointer mb-2">Previas</summary>
+        <summary className="font-semibold cursor-pointer mb-2">Listas previas</summary>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
           {listasPrevias.map((l) => (
             <div


### PR DESCRIPTION
## Summary
- group material lists into Inbox, Future, and Past
- add dropdown menu for adding material tasks
- show toggle to mark finishing place

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b9e1f79308331b11c41ac0e3bcf3e