### PR TITLE
Improve materiales location switch UI

### DIFF
--- a/src/app/proyecto/[id]/materiales/[list]/page.tsx
+++ b/src/app/proyecto/[id]/materiales/[list]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { FolderKanban, ShoppingCart, Building2, Tent, Trash2, Plus } from "lucide-react";
 import Button from "@/components/ui/button";
+import DiagonalToggle from "@/components/ui/diagonal-toggle";
 import {
   Sheet,
   SheetContent,
@@ -536,21 +537,16 @@ export default function MaterialesPage() {
 
                 <div className="flex items-center gap-2 text-sm">
                   <span>Se termina en</span>
-                  <button
-                    onClick={() =>
+                  <DiagonalToggle
+                    value={materialActual.armarEnSanMiguel ? "sanMiguel" : "capital"}
+                    onChange={(v) =>
                       actualizarMaterial(
                         materialActual.id,
                         "armarEnSanMiguel",
-                        !materialActual.armarEnSanMiguel
+                        v === "sanMiguel"
                       )
                     }
-                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${materialActual.armarEnSanMiguel ? "bg-blue-600" : "bg-gray-300"}`}
-                  >
-                    <span
-                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${materialActual.armarEnSanMiguel ? "translate-x-6" : "translate-x-1"}`}
-                    />
-                  </button>
-                  <span>{materialActual.armarEnSanMiguel ? "San Miguel" : "Capital"}</span>
+                  />
                 </div>
 
                 <label className="flex items-center gap-2">

--- a/src/components/ui/diagonal-toggle.tsx
+++ b/src/components/ui/diagonal-toggle.tsx
@@ -1,0 +1,29 @@
+export type DiagonalToggleValue = "capital" | "sanMiguel";
+
+export interface DiagonalToggleProps {
+  value: DiagonalToggleValue;
+  onChange?: (v: DiagonalToggleValue) => void;
+  className?: string;
+}
+
+export default function DiagonalToggle({ value, onChange, className }: DiagonalToggleProps) {
+  return (
+    <div className={`relative inline-block w-32 h-10 rounded overflow-hidden text-sm font-medium ${className || ""}`}> 
+      <div className="absolute inset-0 pointer-events-none bg-[linear-gradient(135deg,transparent_49%,theme(colors.gray.300)_49%,theme(colors.gray.300)_51%,transparent_51%)]" />
+      <button
+        type="button"
+        className={`absolute inset-y-0 left-0 w-1/2 flex items-center justify-center transition-colors ${value === "capital" ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
+        onClick={() => onChange?.("capital")}
+      >
+        Capital
+      </button>
+      <button
+        type="button"
+        className={`absolute inset-y-0 right-0 w-1/2 flex items-center justify-center transition-colors ${value === "sanMiguel" ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
+        onClick={() => onChange?.("sanMiguel")}
+      >
+        San Miguel
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `DiagonalToggle` component for selecting end location
- replace toggle in materiales sheet with diagonal button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c0648a04c8331808642b0db7f736e