### PR TITLE
Add card-style material list creation page

### DIFF
--- a/src/app/proyecto/[id]/materiales/nueva/page.tsx
+++ b/src/app/proyecto/[id]/materiales/nueva/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Button from "@/components/ui/button";
+import { addMaterialList } from "@/lib/supabase/materiales";
+import { PlusCircle, X } from "lucide-react";
+
+export default function NuevaListaPage() {
+  const { id: proyectoId } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [titulo, setTitulo] = useState("");
+  const [fecha, setFecha] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const handleCrear = async () => {
+    if (!proyectoId || creating || !titulo.trim() || !fecha) return;
+    setCreating(true);
+    try {
+      const row = await addMaterialList(proyectoId, titulo.trim(), fecha);
+      router.push(`/proyecto/${proyectoId}/materiales/${row.id}`);
+    } catch {
+      alert("Error creando lista");
+    }
+    setCreating(false);
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-24 bg-white p-6 rounded-2xl shadow">
+      <Link
+        href=".."
+        className="text-blue-600 hover:underline mb-4 inline-block"
+      >
+        &larr; Volver
+      </Link>
+      <h1 className="text-2xl font-bold mb-4 text-center text-blue-700">
+        Nueva Lista de Materiales
+      </h1>
+      <input
+        type="text"
+        placeholder="Título de la actividad"
+        className="p-2 border rounded w-full mb-4"
+        value={titulo}
+        onChange={(e) => setTitulo(e.target.value)}
+      />
+      <input
+        type="date"
+        className="p-2 border rounded w-full mb-4"
+        value={fecha}
+        onChange={(e) => setFecha(e.target.value)}
+      />
+      <div className="flex gap-2">
+        <Button
+          variant="secondary"
+          className="flex-1"
+          icon={<X className="w-4 h-4" />}
+          onClick={() => router.push("..")}
+        >
+          Cancelar
+        </Button>
+        <Button
+          className="flex-1"
+          onClick={handleCrear}
+          loading={creating}
+          icon={<PlusCircle className="w-4 h-4" />}
+        >
+          Crear
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/proyecto/[id]/materiales/page.tsx
+++ b/src/app/proyecto/[id]/materiales/page.tsx
@@ -2,16 +2,14 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { getMaterialLists, addMaterialList, deleteMaterialList } from "@/lib/supabase/materiales";
+import Link from "next/link";
+import { getMaterialLists, deleteMaterialList } from "@/lib/supabase/materiales";
 import { Trash2 } from "lucide-react";
-import Button from "@/components/ui/button";
 
 export default function MaterialesIndexPage() {
   const { id: proyectoId } = useParams<{ id: string }>();
   const router = useRouter();
   const [listas, setListas] = useState<{ id: string; titulo: string; fecha: string }[]>([]);
-  const [titulo, setTitulo] = useState("");
-  const [fecha, setFecha] = useState("");
   const hoy = new Date().toISOString().split("T")[0];
 
   useEffect(() => {
@@ -21,16 +19,6 @@ export default function MaterialesIndexPage() {
       .catch(() => setListas([]));
   }, [proyectoId]);
 
-  const crearLista = () => {
-    if (!titulo.trim() || !fecha) return;
-    addMaterialList(proyectoId, titulo.trim(), fecha)
-      .then((row) => {
-        setListas((prev) => [...prev, row]);
-        setTitulo("");
-        setFecha("");
-      })
-      .catch(() => alert("Error creando lista"));
-  };
 
   const eliminarLista = (id: string) => {
     if (!confirm("¿Eliminar lista?")) return;
@@ -96,23 +84,13 @@ export default function MaterialesIndexPage() {
           ))}
         </div>
       </details>
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold text-blue-800">Crear nueva lista</h2>
-        <div className="flex flex-col sm:flex-row gap-2">
-          <input
-            value={titulo}
-            onChange={(e) => setTitulo(e.target.value)}
-            placeholder="Título de la actividad"
-            className="border rounded p-2 flex-1"
-          />
-          <input
-            type="date"
-            value={fecha}
-            onChange={(e) => setFecha(e.target.value)}
-            className="border rounded p-2"
-          />
-          <Button onClick={crearLista}>Agregar</Button>
-        </div>
+      <div className="mt-6">
+        <Link
+          href="./materiales/nueva"
+          className="inline-block rounded-md bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
+        >
+          + Crear nueva lista
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new `nueva` page for material lists matching card layout of project creation
- update materials index page to link to new page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c1d5e39f483319266a92529b23bfa