### PR TITLE
Add back link in tasks page

### DIFF
--- a/src/app/dashboard/tareas/page.tsx
+++ b/src/app/dashboard/tareas/page.tsx
@@ -41,6 +41,12 @@ export default function MisTareasPage() {
 
   return (
     <div className="space-y-4">
+      <Link
+        href="/dashboard"
+        className="text-blue-600 hover:underline mb-4 inline-block"
+      >
+        &larr; Volver
+      </Link>
       <h1 className="text-3xl font-bold text-blue-900">Mis tareas</h1>
       {tareas.length === 0 && <p className="text-gray-600">No tienes tareas asignadas.</p>}
       <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- add a back link to return to dashboard from the tasks page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c30c363588331b92b28dead15d81c