### PR TITLE
Refactor back links to use icons

### DIFF
--- a/src/app/dashboard/nuevo/page.tsx
+++ b/src/app/dashboard/nuevo/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
+import BackLink from "@/components/ui/back-link";
 import { supabase } from "@/lib/supabase";
 import Button from "@/components/ui/button";
 import { PlusCircle, X } from "lucide-react";
@@ -49,12 +49,7 @@ export default function NuevoProyectoPage() {
 
   return (
     <div className="max-w-md mx-auto mt-24 bg-white p-6 rounded-2xl shadow">
-      <Link
-        href="/dashboard"
-        className="text-blue-600 hover:underline mb-4 inline-block"
-      >
-        &larr; Volver
-      </Link>
+      <BackLink href="/dashboard" className="mb-4 inline-flex" />
       <h1 className="text-2xl font-bold mb-4 text-center text-blue-700">
         Nuevo Proyecto
       </h1>

--- a/src/app/dashboard/tareas/page.tsx
+++ b/src/app/dashboard/tareas/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import Link from "next/link";
+import BackLink from "@/components/ui/back-link";
 import { getProyectosParaUsuario } from "@/lib/supabase/projects";
 import { getMateriales, MaterialRow, getMaterialLists } from "@/lib/supabase/materiales";
 import { getMadrijNombre } from "@/lib/supabase/madrijim";
@@ -41,12 +42,7 @@ export default function MisTareasPage() {
 
   return (
     <div className="space-y-4">
-      <Link
-        href="/dashboard"
-        className="text-blue-600 hover:underline mb-4 inline-block"
-      >
-        &larr; Volver
-      </Link>
+      <BackLink href="/dashboard" className="mb-4 inline-flex" />
       <h1 className="text-3xl font-bold text-blue-900">Mis tareas</h1>
       {tareas.length === 0 && <p className="text-gray-600">No tienes tareas asignadas.</p>}
       <ul className="space-y-2">

--- a/src/app/dashboard/unirse/page.tsx
+++ b/src/app/dashboard/unirse/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
+import BackLink from "@/components/ui/back-link";
 import { supabase } from "@/lib/supabase";
 import Button from "@/components/ui/button";
 import { Handshake } from "lucide-react";
@@ -45,12 +45,7 @@ export default function UnirseProyectoPage() {
 
   return (
     <div>
-      <Link
-        href="/dashboard"
-        className="text-blue-600 hover:underline mb-4 inline-block"
-      >
-        &larr; Volver
-      </Link>
+      <BackLink href="/dashboard" className="mb-4 inline-flex" />
       <h1 className="text-2xl font-bold mb-4">Unirse a un Proyecto</h1>
       <input
         type="text"

--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -14,7 +14,7 @@ import {
   getSesion,
 } from "@/lib/supabase/asistencias";
 import { supabase } from "@/lib/supabase";
-import { Search, FileUp, Check } from "lucide-react";
+import { Search, FileUp, Check, ArrowLeft } from "lucide-react";
 import Button from "@/components/ui/button";
 
 type AsistenciaRow = {
@@ -260,6 +260,7 @@ export default function AsistenciaPage() {
           className="w-full"
           variant="secondary"
           onClick={() => router.push(`/proyecto/${proyectoId}/janijim`)}
+          icon={<ArrowLeft className="w-4 h-4" />}
         >
           Volver al menú
         </Button>

--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -25,6 +25,8 @@ import {
   Check,
   X,
   Search,
+  ArrowLeft,
+  ArrowUp,
 } from "lucide-react";
 import Button from "@/components/ui/button";
 import Skeleton from "@/components/ui/skeleton";
@@ -563,6 +565,7 @@ export default function JanijimPage() {
       <Button
         className="mx-auto mt-4 block"
         onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+        icon={<ArrowUp className="w-4 h-4" />}
       >
         Volver arriba
       </Button>
@@ -614,9 +617,10 @@ export default function JanijimPage() {
               <SheetFooter>
                 <button
                   onClick={() => setImportMode("chooser")}
-                  className="px-4 py-2 bg-gray-200 rounded-lg"
+                  className="px-4 py-2 bg-gray-200 rounded-lg inline-flex items-center gap-1"
                 >
-                  Volver
+                  <ArrowLeft className="w-4 h-4" />
+                  <span>Volver</span>
                 </button>
               </SheetFooter>
             </>
@@ -645,6 +649,7 @@ export default function JanijimPage() {
                 <Button
                   variant="secondary"
                   onClick={() => setImportMode("chooser")}
+                  icon={<ArrowLeft className="w-4 h-4" />}
                 >
                   Volver
                 </Button>

--- a/src/app/proyecto/[id]/materiales/nueva/page.tsx
+++ b/src/app/proyecto/[id]/materiales/nueva/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import Link from "next/link";
+import BackLink from "@/components/ui/back-link";
 import Button from "@/components/ui/button";
 import { addMaterialList } from "@/lib/supabase/materiales";
 import { PlusCircle, X } from "lucide-react";
@@ -29,12 +29,7 @@ export default function NuevaListaPage() {
 
   return (
     <div className="max-w-md mx-auto mt-24 bg-white p-6 rounded-2xl shadow">
-      <Link
-        href=".."
-        className="text-blue-600 hover:underline mb-4 inline-block"
-      >
-        &larr; Volver
-      </Link>
+      <BackLink href=".." className="mb-4 inline-flex" />
       <h1 className="text-2xl font-bold mb-4 text-center text-blue-700">
         Nueva Lista de Materiales
       </h1>

--- a/src/components/ui/back-link.tsx
+++ b/src/components/ui/back-link.tsx
@@ -1,0 +1,29 @@
+"use client";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface BackLinkProps {
+  href: string;
+  className?: string;
+  label?: string;
+}
+
+export default function BackLink({
+  href,
+  className,
+  label = "Volver",
+}: BackLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "inline-flex items-center gap-1 text-blue-600 hover:underline",
+        className
+      )}
+    >
+      <ArrowLeft className="w-4 h-4" />
+      <span>{label}</span>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- add BackLink component for consistent back navigation styling
- replace textual back links with BackLink
- add arrow icons to various Back and "Volver" buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c313bbc108331a12d2a5482eaafbe