### PR TITLE
Improve attendance buttons

### DIFF
--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -489,6 +489,7 @@ export default function JanijimPage() {
               </Button>
             </div>
             <Button
+              variant="success"
               className="w-full sm:w-auto shrink-0 sm:ml-2"
               icon={<Check className="w-4 h-4" />}
               onClick={() => setSesionOpen(true)}
@@ -761,7 +762,11 @@ export default function JanijimPage() {
             </select>
           </div>
           <SheetFooter>
-            <Button icon={<Check className="w-4 h-4" />} onClick={iniciarSesion}>
+            <Button
+              variant="success"
+              icon={<Check className="w-4 h-4" />}
+              onClick={iniciarSesion}
+            >
               Iniciar
             </Button>
           </SheetFooter>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "primary" | "secondary" | "danger";
+  variant?: "primary" | "secondary" | "danger" | "success";
   loading?: boolean;
   icon?: React.ReactNode;
   iconRight?: boolean;
@@ -25,6 +25,7 @@ export default function Button({
     primary: "bg-blue-600 text-white hover:bg-blue-700",
     secondary: "bg-gray-200 text-gray-700 hover:bg-gray-300",
     danger: "bg-red-600 text-white hover:bg-red-700",
+    success: "bg-green-600 text-white hover:bg-green-700",
   };
 
   return (


### PR DESCRIPTION
## Summary
- update `Button` component with new `success` variant
- show green `Iniciar asistencia del día` button in janijim page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c332b700083319dfbce622da70121