### PR TITLE
Fix navigation highlight and back buttons

### DIFF
--- a/src/app/proyecto/[id]/materiales/[list]/page.tsx
+++ b/src/app/proyecto/[id]/materiales/[list]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import Button from "@/components/ui/button";
+import BackLink from "@/components/ui/back-link";
 import DiagonalToggle from "@/components/ui/diagonal-toggle";
 import {
   Sheet,
@@ -214,6 +215,10 @@ export default function MaterialesPage() {
 
   return (
     <div className="space-y-8">
+      <BackLink
+        href={`/proyecto/${proyectoId}/materiales`}
+        className="inline-flex"
+      />
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-3xl font-bold flex items-center gap-2 text-blue-900">
           <FolderKanban className="w-7 h-7" /> Organización de Materiales

--- a/src/app/proyecto/[id]/materiales/nueva/page.tsx
+++ b/src/app/proyecto/[id]/materiales/nueva/page.tsx
@@ -30,7 +30,10 @@ export default function NuevaListaPage() {
 
   return (
     <div className="max-w-md mx-auto mt-24 bg-white p-6 rounded-2xl shadow">
-      <BackLink href=".." className="mb-4 inline-flex" />
+      <BackLink
+        href={`/proyecto/${proyectoId}/materiales`}
+        className="mb-4 inline-flex"
+      />
       <h1 className="text-2xl font-bold mb-4 text-center text-blue-700">
         Nueva Lista de Materiales
       </h1>
@@ -52,7 +55,9 @@ export default function NuevaListaPage() {
           variant="secondary"
           className="flex-1"
           icon={<X className="w-4 h-4" />}
-          onClick={() => router.push("..")}
+          onClick={() =>
+            router.push(`/proyecto/${proyectoId}/materiales`)
+          }
         >
           Cancelar
         </Button>

--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -56,7 +56,10 @@ export default function MobileMenu({ proyectoId }: MobileMenuProps) {
                   : href
                   ? `/proyecto/${proyectoId}/${href}`
                   : `/proyecto/${proyectoId}`;
-                const isActive = pathname === fullPath || pathname === fullPath + "/";
+                const isRoot = href === "";
+                const isActive = isRoot
+                  ? pathname === fullPath || pathname === fullPath + "/"
+                  : pathname === fullPath || pathname.startsWith(fullPath + "/");
 
                 return (
                   <SheetClose asChild key={href}>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -42,7 +42,10 @@ export default function Sidebar({ proyectoId }: { proyectoId: string }) {
             : href
             ? `/proyecto/${proyectoId}/${href}`
             : `/proyecto/${proyectoId}`;
-          const isActive = pathname === fullPath || pathname === fullPath + "/";
+          const isRoot = href === "";
+          const isActive = isRoot
+            ? pathname === fullPath || pathname === fullPath + "/"
+            : pathname === fullPath || pathname.startsWith(fullPath + "/");
 
           return (
             <Link


### PR DESCRIPTION
## Summary
- fix sidebar and mobile menu active link logic
- use absolute paths for back links in material lists
- add back link to materials list page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c3736e9dc8331bcc4646a67d8d51e