### PR TITLE
Add icons to action buttons

### DIFF
--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -584,18 +584,20 @@ export default function JanijimPage() {
                 </SheetDescription>
               </SheetHeader>
               <div className="p-4 space-y-4">
-                <button
+                <Button
                   onClick={() => setImportMode("file")}
-                  className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg"
+                  className="w-full"
+                  icon={<FileUp className="w-4 h-4" />}
                 >
                   Desde archivo
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => setImportMode("manual")}
-                  className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg"
+                  className="w-full"
+                  icon={<Pencil className="w-4 h-4" />}
                 >
                   Escribir manualmente
-                </button>
+                </Button>
               </div>
             </>
           )}
@@ -609,12 +611,13 @@ export default function JanijimPage() {
                 </SheetDescription>
               </SheetHeader>
               <div className="p-4 space-y-4">
-                <button
+                <Button
                   onClick={() => fileInput.current?.click()}
-                  className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg"
+                  className="w-full"
+                  icon={<FileUp className="w-4 h-4" />}
                 >
                   Seleccionar archivo
-                </button>
+                </Button>
               </div>
               <SheetFooter>
                 <button
@@ -721,12 +724,12 @@ export default function JanijimPage() {
             </div>
           )}
           <SheetFooter>
-            <button
+            <Button
               onClick={confirmImport}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+              icon={<FileUp className="w-4 h-4" />}
             >
               Insertar
-            </button>
+            </Button>
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/src/app/proyecto/[id]/materiales/[list]/page.tsx
+++ b/src/app/proyecto/[id]/materiales/[list]/page.tsx
@@ -9,6 +9,7 @@ import {
   Tent,
   Trash2,
   Plus,
+  X,
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import Button from "@/components/ui/button";
@@ -223,7 +224,13 @@ export default function MaterialesPage() {
         <h1 className="text-3xl font-bold flex items-center gap-2 text-blue-900">
           <FolderKanban className="w-7 h-7" /> Organización de Materiales
         </h1>
-        <Button variant="danger" onClick={eliminarLista}>Eliminar lista</Button>
+        <Button
+          variant="danger"
+          onClick={eliminarLista}
+          icon={<Trash2 className="w-4 h-4" />}
+        >
+          Eliminar lista
+        </Button>
       </div>
 
       {/* Cosas para hacer */}
@@ -236,7 +243,9 @@ export default function MaterialesPage() {
             placeholder="Nuevo material"
             className="border rounded p-2 flex-1"
           />
-          <Button onClick={crearMaterial}>Agregar</Button>
+          <Button onClick={crearMaterial} icon={<Plus className="w-4 h-4" />}>
+            Agregar
+          </Button>
         </div>
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-2">
           <label htmlFor="filtroAsignado" className="text-sm text-gray-700">
@@ -465,6 +474,7 @@ export default function MaterialesPage() {
                         placeholder="Nuevo item"
                       />
                       <Button
+                        icon={<Plus className="w-4 h-4" />}
                         onClick={() => {
                           const campo: "compraItems" | "sedeItems" | "sanMiguelItems" =
                             tipoNuevoItem === "compra"
@@ -482,6 +492,7 @@ export default function MaterialesPage() {
                       <Button
                         variant="secondary"
                         onClick={() => setMostrarAgregar(false)}
+                        icon={<X className="w-4 h-4" />}
                       >
                         Cancelar
                       </Button>
@@ -593,11 +604,16 @@ export default function MaterialesPage() {
                     variant="danger"
                     onClick={() => eliminarMaterial(materialActual.id)}
                     className="flex-1"
+                    icon={<Trash2 className="w-4 h-4" />}
                   >
                     Eliminar
                   </Button>
                   <SheetClose asChild>
-                    <Button variant="secondary" className="flex-1">
+                    <Button
+                      variant="secondary"
+                      className="flex-1"
+                      icon={<X className="w-4 h-4" />}
+                    >
                       Cerrar
                     </Button>
                   </SheetClose>

--- a/src/app/proyecto/[id]/materiales/page.tsx
+++ b/src/app/proyecto/[id]/materiales/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { getMaterialLists, deleteMaterialList } from "@/lib/supabase/materiales";
-import { Trash2 } from "lucide-react";
+import { Trash2, PlusCircle } from "lucide-react";
 import { showError, confirmDialog } from "@/lib/alerts";
 
 export default function MaterialesIndexPage() {
@@ -88,9 +88,10 @@ export default function MaterialesIndexPage() {
       <div className="mt-6">
         <Link
           href="./materiales/nueva"
-          className="inline-block rounded-md bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
+          className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
         >
-          + Crear nueva lista
+          <PlusCircle className="w-4 h-4" />
+          <span>Crear nueva lista</span>
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show plus icon when creating new material lists
- use icons for deleting and managing materials
- style import buttons with icons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c394ce8fc8331bb82833e412a293c