### PR TITLE
Add per-column task input

### DIFF
--- a/src/app/proyecto/[id]/materiales/[list]/page.tsx
+++ b/src/app/proyecto/[id]/materiales/[list]/page.tsx
@@ -77,6 +77,11 @@ export default function MaterialesPage() {
 
   const [materiales, setMateriales] = useState<Material[]>([]);
   const [nuevoNombre, setNuevoNombre] = useState("");
+  const [nuevoPorEstado, setNuevoPorEstado] = useState<Record<Estado, string>>({
+    "por hacer": "",
+    "en proceso": "",
+    realizado: "",
+  });
 
   const [madrijes, setMadrijes] = useState<{ clerk_id: string; nombre: string }[]>([]);
   const [nuevoItemGeneral, setNuevoItemGeneral] = useState("");
@@ -108,6 +113,17 @@ export default function MaterialesPage() {
       .then((row) => {
         setMateriales((prev) => [...prev, rowToMaterial(row)]);
         setNuevoNombre("");
+      })
+      .catch(() => showError("Error creando material"));
+  };
+
+  const crearMaterialEnEstado = (estado: Estado) => {
+    const nombre = nuevoPorEstado[estado].trim();
+    if (!nombre || !list) return;
+    addMaterialEnLista(list, nombre, proyectoId, estado)
+      .then((row) => {
+        setMateriales((prev) => [...prev, rowToMaterial(row)]);
+        setNuevoPorEstado((prev) => ({ ...prev, [estado]: "" }));
       })
       .catch(() => showError("Error creando material"));
   };
@@ -319,6 +335,28 @@ export default function MaterialesPage() {
                 ).length === 0 && (
                   <p className="text-sm text-gray-500">Sin materiales</p>
                 )}
+                <div className="pt-2 flex items-center gap-2">
+                  <input
+                    value={nuevoPorEstado[estado]}
+                    onChange={(e) =>
+                      setNuevoPorEstado((prev) => ({
+                        ...prev,
+                        [estado]: e.target.value,
+                      }))
+                    }
+                    onKeyDown={(e) =>
+                      e.key === "Enter" && crearMaterialEnEstado(estado)
+                    }
+                    placeholder="Agregar material"
+                    className="flex-1 bg-transparent border-b border-gray-300 focus:outline-none"
+                  />
+                  <button
+                    onClick={() => crearMaterialEnEstado(estado)}
+                    className="text-blue-600 hover:text-blue-800"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+                </div>
               </div>
             </div>
           ))}

--- a/src/lib/supabase/materiales.ts
+++ b/src/lib/supabase/materiales.ts
@@ -70,11 +70,12 @@ export async function addMaterial(proyectoId: string, nombre: string) {
 export async function addMaterialEnLista(
   listaId: string,
   nombre: string,
-  proyectoId: string
+  proyectoId: string,
+  estado: string = "por hacer"
 ) {
   const { data, error } = await supabase
     .from("materiales")
-    .insert({ proyecto_id: proyectoId, lista_id: listaId, nombre })
+    .insert({ proyecto_id: proyectoId, lista_id: listaId, nombre, estado })
     .select()
     .single();
   if (error) throw error;


### PR DESCRIPTION
## Summary
- allow specifying status when creating materials
- show input field in each column to add materials directly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c3c4469d48331ac646cade2405e17