### PR TITLE
Add card-style create button for material lists

### DIFF
--- a/src/app/proyecto/[id]/materiales/page.tsx
+++ b/src/app/proyecto/[id]/materiales/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import Link from "next/link";
 import { getMaterialLists, deleteMaterialList } from "@/lib/supabase/materiales";
 import { Trash2, PlusCircle } from "lucide-react";
 import { showError, confirmDialog } from "@/lib/alerts";
@@ -58,6 +57,14 @@ export default function MaterialesIndexPage() {
               <p className="text-sm text-gray-600">{l.fecha}</p>
             </div>
           ))}
+          <div
+            key="crear"
+            onClick={() => router.push("./materiales/nueva")}
+            className="cursor-pointer rounded border-2 border-dashed p-4 bg-white flex flex-col items-center justify-center text-gray-500 hover:bg-gray-50"
+          >
+            <PlusCircle className="w-6 h-6" />
+            <span className="mt-2 font-semibold">Crear nueva lista</span>
+          </div>
         </div>
       </details>
 
@@ -85,15 +92,6 @@ export default function MaterialesIndexPage() {
           ))}
         </div>
       </details>
-      <div className="mt-6">
-        <Link
-          href="./materiales/nueva"
-          className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
-        >
-          <PlusCircle className="w-4 h-4" />
-          <span>Crear nueva lista</span>
-        </Link>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style list creation as a card within the material lists grid
- keep card at the end of the "bandeja" grid so new lists appear before it

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c400c3008833197a47b0ca7f54fd6