### PR TITLE
Fix classification of today's material lists

### DIFF
--- a/src/app/proyecto/[id]/materiales/page.tsx
+++ b/src/app/proyecto/[id]/materiales/page.tsx
@@ -27,8 +27,8 @@ export default function MaterialesIndexPage() {
       .catch(() => showError("Error eliminando lista"));
   };
 
-  const bandeja = listas.filter((l) => l.fecha > hoy);
-  const listasPrevias = listas.filter((l) => !l.fecha || l.fecha <= hoy);
+  const bandeja = listas.filter((l) => l.fecha >= hoy);
+  const listasPrevias = listas.filter((l) => !l.fecha || l.fecha < hoy);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- categorize material lists dated today into the inbox

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d891e7ef883319820ff3970d82a59