### PR TITLE
Fix mobile responsiveness for materials pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <ClerkProvider>
       <html lang="es">
+        <head>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+        </head>
         <body className="antialiased bg-gray-50 text-gray-800">
           <ClientBootstrap />
           <ToastProvider />

--- a/src/app/proyecto/[id]/materiales/[list]/page.tsx
+++ b/src/app/proyecto/[id]/materiales/[list]/page.tsx
@@ -1328,7 +1328,11 @@ export default function MaterialesPage() {
 
 
       <Sheet open={importOpen} onOpenChange={setImportOpen}>
-        <SheetContent side="bottom" className="w-full">
+        <SheetContent
+          side="bottom"
+          className="w-full"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
           <SheetHeader>
             <SheetTitle>Importar materiales</SheetTitle>
             <SheetDescription>
@@ -1348,7 +1352,11 @@ export default function MaterialesPage() {
       </Sheet>
 
       <Sheet open={columnOpen} onOpenChange={setColumnOpen}>
-        <SheetContent side="bottom" className="w-full">
+        <SheetContent
+          side="bottom"
+          className="w-full"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
           <SheetHeader>
             <SheetTitle>Elegí las columnas</SheetTitle>
             <SheetDescription>
@@ -1419,6 +1427,7 @@ export default function MaterialesPage() {
         <SheetContent
           side={isDesktop ? "right" : "bottom"}
           className="w-full sm:w-96 h-dvh"
+          onOpenAutoFocus={(e) => e.preventDefault()}
         >
           {materialActual && (
             <div className="flex flex-col h-full">


### PR DESCRIPTION
## Summary
- ensure pages scale correctly by adding viewport meta tag
- prevent Radix sheets from auto-focusing inputs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68558fca57fc8331834664bc37a3519a