### PR TITLE
Centralize navigation links

### DIFF
--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -13,23 +13,12 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { UserButton } from "@clerk/nextjs";
+import { navigationLinks as links } from "@/lib/navigationLinks";
 
 type MobileMenuProps = {
   proyectoId: string;
 };
 
-const links = [
-  { href: "/dashboard", label: "Mis Proyectos" },
-  { href: "", label: "Inicio" },
-  { href: "janijim", label: "Janijim" },
-  { href: "materiales", label: "Materiales" },
-  { href: "notas", label: "Notas" },
-  { href: "calendario", label: "Calendario" },
-  { href: "tareas", label: "Tareas" },
-  { href: "planificaciones", label: "Planificaciones" },
-  { href: "actividades", label: "Actividades" },
-  { href: "chatbot", label: "Chatbot" },
-];
 
 export default function MobileMenu({ proyectoId }: MobileMenuProps) {
   const pathname = usePathname();

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -4,31 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { UserButton } from "@clerk/nextjs";
-import {
-  ClipboardList,
-  Book,
-  Calendar,
-  CheckSquare,
-  PencilRuler,
-  PartyPopper,
-  Bot,
-  Home,
-  LayoutDashboard,
-  FolderKanban,
-} from "lucide-react";
-
-const links = [
-  { href: "/dashboard", label: "Mis Proyectos", icon: LayoutDashboard },
-  { href: "", label: "Inicio", icon: Home },
-  { href: "janijim", label: "Janijim", icon: ClipboardList },
-  { href: "materiales", label: "Materiales", icon: FolderKanban },
-  { href: "notas", label: "Notas", icon: Book },
-  { href: "calendario", label: "Calendario", icon: Calendar },
-  { href: "tareas", label: "Tareas", icon: CheckSquare },
-  { href: "planificaciones", label: "Planificaciones", icon: PencilRuler },
-  { href: "actividades", label: "Actividades", icon: PartyPopper },
-  { href: "chatbot", label: "Chatbot", icon: Bot },
-];
+import { navigationLinks as links } from "@/lib/navigationLinks";
 
 export default function Sidebar({ proyectoId }: { proyectoId: string }) {
   const pathname = usePathname();
@@ -58,7 +34,7 @@ export default function Sidebar({ proyectoId }: { proyectoId: string }) {
                   : "text-gray-700 hover:bg-gray-100"
               )}
             >
-              <Icon size={18} />
+              {Icon && <Icon size={18} />}
               <span>{label}</span>
             </Link>
           );

--- a/src/lib/navigationLinks.ts
+++ b/src/lib/navigationLinks.ts
@@ -1,0 +1,32 @@
+import {
+  ClipboardList,
+  Book,
+  Calendar,
+  CheckSquare,
+  PencilRuler,
+  PartyPopper,
+  Bot,
+  Home,
+  LayoutDashboard,
+  FolderKanban,
+  type LucideIcon,
+} from "lucide-react";
+
+export interface NavigationLink {
+  href: string;
+  label: string;
+  icon?: LucideIcon;
+}
+
+export const navigationLinks: NavigationLink[] = [
+  { href: "/dashboard", label: "Mis Proyectos", icon: LayoutDashboard },
+  { href: "", label: "Inicio", icon: Home },
+  { href: "janijim", label: "Janijim", icon: ClipboardList },
+  { href: "materiales", label: "Materiales", icon: FolderKanban },
+  { href: "notas", label: "Notas", icon: Book },
+  { href: "calendario", label: "Calendario", icon: Calendar },
+  { href: "tareas", label: "Tareas", icon: CheckSquare },
+  { href: "planificaciones", label: "Planificaciones", icon: PencilRuler },
+  { href: "actividades", label: "Actividades", icon: PartyPopper },
+  { href: "chatbot", label: "Chatbot", icon: Bot },
+];


### PR DESCRIPTION
## Summary
- add shared `navigationLinks` export
- use this list in sidebar and mobile menu components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c2b201b4c8331be16b9b9f0afd96a