### PR TITLE
Add mobile bottom navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,3 +126,9 @@
     @apply cursor-pointer disabled:cursor-not-allowed;
   }
 }
+
+@layer base {
+  html {
+    @apply scroll-smooth touch-manipulation;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,9 +51,12 @@ export default function HomePage() {
       <SignInButton mode="modal" withSignUp forceRedirectUrl="/dashboard" signUpForceRedirectUrl="/dashboard">
         <Button icon={<LogIn className="w-4 h-4" />}>Iniciar sesión</Button>
       </SignInButton>
-      <section className="mt-12 grid gap-6 w-full max-w-5xl md:grid-cols-3">
+      <section className="mt-12 grid gap-6 w-full max-w-5xl sm:grid-cols-2 md:grid-cols-3">
         {features.map(({ icon: Icon, title, desc }) => (
-          <div key={title} className="flex flex-col items-center bg-white/60 backdrop-blur rounded-lg p-6 shadow">
+          <div
+            key={title}
+            className="flex flex-col items-center bg-white/60 backdrop-blur rounded-xl p-6 shadow-md"
+          >
             <Icon className="w-10 h-10 text-blue-600 mb-4" />
             <h3 className="text-lg font-semibold mb-2">{title}</h3>
             <p className="text-sm text-gray-600">{desc}</p>

--- a/src/app/proyecto/[id]/layout.tsx
+++ b/src/app/proyecto/[id]/layout.tsx
@@ -1,5 +1,6 @@
 import Sidebar from "@/components/ui/sidebar";
 import MobileMenu from "@/components/ui/mobile-menu";
+import BottomNav from "@/components/ui/bottom-nav";
 
 export default async function ProyectoLayout({
   children,
@@ -13,9 +14,10 @@ export default async function ProyectoLayout({
   return (
     <div className="min-h-screen md:flex">
       <Sidebar proyectoId={proyectoId} />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col pb-16 pt-16">
         <MobileMenu proyectoId={proyectoId} />
-        <main className="p-6">{children}</main>
+        <main className="flex-1 p-6 pb-20">{children}</main>
+        <BottomNav proyectoId={proyectoId} />
       </div>
     </div>
   );

--- a/src/components/ui/bottom-nav.tsx
+++ b/src/components/ui/bottom-nav.tsx
@@ -1,0 +1,43 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { navigationLinks as links } from "@/lib/navigationLinks";
+
+export default function BottomNav({ proyectoId }: { proyectoId: string }) {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      className="md:hidden fixed bottom-0 inset-x-0 z-20 bg-white/90 backdrop-blur border-t shadow flex justify-around py-2"
+      style={{ WebkitBackdropFilter: "blur(8px)" }}
+    >
+      {links.map(({ href, label, icon: Icon }) => {
+        const fullPath = href.startsWith("/")
+          ? href
+          : href
+          ? `/proyecto/${proyectoId}/${href}`
+          : `/proyecto/${proyectoId}`;
+        const isRoot = href === "";
+        const isActive = isRoot
+          ? pathname === fullPath || pathname === fullPath + "/"
+          : pathname === fullPath || pathname.startsWith(fullPath + "/");
+        return (
+          <Link
+            key={href}
+            href={fullPath}
+            className={cn(
+              "flex flex-col items-center justify-center gap-0.5 text-xs py-1 flex-1 transition-colors",
+              isActive
+                ? "text-blue-600 border-t-2 border-blue-600 bg-blue-50"
+                : "text-gray-600 hover:text-blue-600"
+            )}
+          >
+            {Icon && <Icon size={24} />}
+            <span className="leading-none">{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -24,7 +24,10 @@ export default function MobileMenu({ proyectoId }: MobileMenuProps) {
   const pathname = usePathname();
 
   return (
-    <div className="md:hidden p-4 bg-white shadow-md flex items-center justify-between">
+    <div
+      className="md:hidden fixed top-0 inset-x-0 z-20 p-4 bg-white/90 shadow-md backdrop-blur flex items-center justify-between"
+      style={{ WebkitBackdropFilter: "blur(8px)" }}
+    >
       <div className="flex items-center gap-4">
         <Sheet>
           <SheetTrigger aria-label="Abrir men\u00fa de navegaci\u00f3n">


### PR DESCRIPTION
## Summary
- create `<BottomNav>` component for quick access on phones
- show bottom navigation in project layout
- improve mobile responsiveness with sticky menu and smoother scrolling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c2cd89ce88331be5b06c11156005d