### PR TITLE
Improve mobile spacing for project pages

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -19,7 +19,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         </div>
         <UserButton afterSignOutUrl="/" />
       </header>
-      <main className="p-6">{children}</main>
+      <main className="flex-1 p-4 md:p-6 w-full max-w-4xl mx-auto">{children}</main>
     </div>
   );
 }

--- a/src/app/dashboard/nuevo/page.tsx
+++ b/src/app/dashboard/nuevo/page.tsx
@@ -58,7 +58,7 @@ export default function NuevoProyectoPage() {
       <input
         type="text"
         placeholder="Ej.: Campamento de verano"
-        className="p-2 border rounded w-full mb-4"
+        className="p-2 border rounded w-full mb-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
         value={nombre}
         onChange={(e) => setNombre(e.target.value)}
       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,7 +51,7 @@ export default function HomePage() {
       <SignInButton mode="modal" withSignUp forceRedirectUrl="/dashboard" signUpForceRedirectUrl="/dashboard">
         <Button icon={<LogIn className="w-4 h-4" />}>Iniciar sesión</Button>
       </SignInButton>
-      <section className="mt-12 grid gap-6 w-full max-w-5xl sm:grid-cols-2 md:grid-cols-3">
+      <section className="mt-12 grid gap-6 w-full max-w-5xl mx-auto sm:grid-cols-2 md:grid-cols-3">
         {features.map(({ icon: Icon, title, desc }) => (
           <div
             key={title}

--- a/src/app/proyecto/[id]/layout.tsx
+++ b/src/app/proyecto/[id]/layout.tsx
@@ -15,7 +15,7 @@ export default async function ProyectoLayout({
       <Sidebar proyectoId={proyectoId} />
       <div className="flex-1 flex flex-col">
         <MobileMenu proyectoId={proyectoId} />
-        <main className="p-6">{children}</main>
+        <main className="p-4 md:p-6 pt-20 md:pt-6 w-full max-w-4xl mx-auto">{children}</main>
       </div>
     </div>
   );

--- a/src/components/ui/mobile-menu.tsx
+++ b/src/components/ui/mobile-menu.tsx
@@ -57,9 +57,12 @@ export default function MobileMenu({ proyectoId }: MobileMenuProps) {
                   <SheetClose asChild key={href}>
                     <Link
                       href={fullPath}
+                      aria-current={isActive ? "page" : undefined}
                       className={cn(
                         "block text-base font-medium",
-                        isActive ? "text-blue-700" : "text-gray-700"
+                        isActive
+                          ? "text-blue-700 font-semibold"
+                          : "text-gray-700"
                       )}
                     >
                       {label}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -27,11 +27,12 @@ export default function Sidebar({ proyectoId }: { proyectoId: string }) {
             <Link
               key={href}
               href={fullPath}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
-                "flex items-center gap-3 px-4 py-2 rounded-md transition",
+                "flex items-center gap-3 px-4 py-2 rounded-md transition border-l-4",
                 isActive
-                  ? "bg-black text-white"
-                  : "text-gray-700 hover:bg-gray-100"
+                  ? "bg-blue-50 text-blue-800 border-blue-600 font-semibold"
+                  : "text-gray-700 border-transparent hover:bg-gray-100"
               )}
             >
               {Icon && <Icon size={18} />}


### PR DESCRIPTION
## Summary
- prevent mobile header overlap in project layout
- add container widths and active navigation styling
- improve input and grid spacing across pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c31f3daa0833196568f671e25ff13