### PR TITLE
Add janij detail modal and DB columns

### DIFF
--- a/sql/migrations/20240628_add_janij_details.sql
+++ b/sql/migrations/20240628_add_janij_details.sql
@@ -1,0 +1,9 @@
+-- Add extra details to janijim
+ALTER TABLE public.janijim
+  ADD COLUMN apellido text,
+  ADD COLUMN dni text,
+  ADD COLUMN numero_socio text,
+  ADD COLUMN grupo text,
+  ADD COLUMN tel_madre text,
+  ADD COLUMN tel_padre text,
+  ADD COLUMN extras jsonb DEFAULT '{}'::jsonb;

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function Modal({ ...props }: React.ComponentProps<typeof Dialog.Root>) {
+  return <Dialog.Root {...props} />;
+}
+
+function ModalTrigger({ ...props }: React.ComponentProps<typeof Dialog.Trigger>) {
+  return <Dialog.Trigger {...props} />;
+}
+
+function ModalPortal({ ...props }: React.ComponentProps<typeof Dialog.Portal>) {
+  return <Dialog.Portal {...props} />;
+}
+
+function ModalOverlay({ className, ...props }: React.ComponentProps<typeof Dialog.Overlay>) {
+  return (
+    <Dialog.Overlay
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ModalContent({ className, children, ...props }: React.ComponentProps<typeof Dialog.Content>) {
+  return (
+    <ModalPortal>
+      <ModalOverlay />
+      <Dialog.Content
+        className={cn(
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-1/2 top-1/2 z-50 grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-300",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <Dialog.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </Dialog.Close>
+      </Dialog.Content>
+    </ModalPortal>
+  );
+}
+
+function ModalHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1.5 text-center", className)} {...props} />;
+}
+
+function ModalFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("mt-4 flex justify-end gap-2", className)} {...props} />;
+}
+
+function ModalTitle({ className, ...props }: React.ComponentProps<typeof Dialog.Title>) {
+  return <Dialog.Title className={cn("text-lg font-semibold", className)} {...props} />;
+}
+
+function ModalDescription({ className, ...props }: React.ComponentProps<typeof Dialog.Description>) {
+  return <Dialog.Description className={cn("text-sm text-gray-500", className)} {...props} />;
+}
+
+export {
+  Modal,
+  ModalTrigger,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalTitle,
+  ModalDescription,
+};

--- a/src/lib/supabase/janijim.ts
+++ b/src/lib/supabase/janijim.ts
@@ -1,9 +1,22 @@
 import { supabase } from "@/lib/supabase";
 
+export type JanijData = {
+  nombre: string;
+  apellido?: string | null;
+  dni?: string | null;
+  numero_socio?: string | null;
+  grupo?: string | null;
+  tel_madre?: string | null;
+  tel_padre?: string | null;
+  extras?: Record<string, unknown> | null;
+};
+
 export async function getJanijim(proyectoId: string) {
   const { data, error } = await supabase
     .from("janijim")
-    .select("id, nombre")
+    .select(
+      "id, nombre, apellido, dni, numero_socio, grupo, tel_madre, tel_padre, extras",
+    )
     .eq("proyecto_id", proyectoId)
     .eq("activo", true)
     .order("nombre", { ascending: true });
@@ -11,15 +24,18 @@ export async function getJanijim(proyectoId: string) {
   return data;
 }
 
-export async function addJanijim(proyectoId: string, nombres: string[]) {
-  const payload = nombres.map((nombre) => ({ nombre, proyecto_id: proyectoId }));
-  const { data, error } = await supabase.from("janijim").insert(payload).select();
+export async function addJanijim(proyectoId: string, items: JanijData[]) {
+  const payload = items.map((item) => ({ ...item, proyecto_id: proyectoId }));
+  const { data, error } = await supabase
+    .from("janijim")
+    .insert(payload)
+    .select();
   if (error) throw error;
   return data;
 }
 
-export async function updateJanij(id: string, nombre: string) {
-  const { error } = await supabase.from("janijim").update({ nombre }).eq("id", id);
+export async function updateJanij(id: string, data: Partial<JanijData>) {
+  const { error } = await supabase.from("janijim").update(data).eq("id", id);
   if (error) throw error;
 }
 


### PR DESCRIPTION
## Summary
- extend janijim table with new detail columns
- add Modal component for centered dialogs
- update Supabase client to handle extra janij fields
- enhance janijim page with detail view and CSV column mapping importer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ff1aec1108331bfcc47458aff1988