### PR TITLE
Improve responsible call modal

### DIFF
--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -51,7 +51,7 @@ import {
 import { parseSpreadsheetFile } from "@/lib/utils";
 import { crearSesion } from "@/lib/supabase/asistencias";
 import { getMadrijimPorProyecto } from "@/lib/supabase/madrijim-client";
-import { showError, confirmDialog } from "@/lib/alerts";
+import { showError, confirmDialog, chooseParentDialog } from "@/lib/alerts";
 
 
 type Janij = {
@@ -251,12 +251,25 @@ export default function JanijimPage() {
   };
 
   const callResponsible = async () => {
-    const phone = editTelMadre.trim() || editTelPadre.trim();
-    if (!phone) {
+    const madre = editTelMadre.trim();
+    const padre = editTelPadre.trim();
+
+    if (!madre && !padre) {
       toast.error("No hay teléfono cargado");
       return;
     }
-    if (!(await confirmDialog("¿Llamar al adulto responsable?"))) return;
+
+    let phone = madre || padre;
+
+    if (madre && padre) {
+      const option = await chooseParentDialog("¿A quién querés llamar?");
+      if (option === "madre") phone = madre;
+      else if (option === "padre") phone = padre;
+      else return; // cancel
+    } else {
+      if (!(await confirmDialog("¿Llamar al adulto responsable?"))) return;
+    }
+
     const sanitized = phone.replace(/[^+\d]/g, "");
     const url = `tel:${sanitized}`;
     // Using window.open with _self ensures the tel: URL triggers the phone dialer

--- a/src/lib/alerts.ts
+++ b/src/lib/alerts.ts
@@ -22,3 +22,24 @@ export async function confirmDialog(message: string) {
   });
   return result.isConfirmed;
 }
+
+export type ParentOption = 'madre' | 'padre' | null;
+
+export async function chooseParentDialog(message: string): Promise<ParentOption> {
+  const result = await Swal.fire({
+    title: message,
+    icon: 'question',
+    showDenyButton: true,
+    showCancelButton: true,
+    confirmButtonColor: '#2563eb',
+    denyButtonColor: '#2563eb',
+    cancelButtonColor: '#6b7280',
+    confirmButtonText: 'Mamá',
+    denyButtonText: 'Papá',
+    cancelButtonText: 'Cancelar',
+  });
+
+  if (result.isConfirmed) return 'madre';
+  if (result.isDenied) return 'padre';
+  return null;
+}


### PR DESCRIPTION
## Summary
- add parent selection dialog helper
- handle father vs. mother choice when calling a responsible adult

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68617c0df178833196af5d06c91e9087