### PR TITLE
Add phone permission confirmation

### DIFF
--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -272,8 +272,10 @@ export default function JanijimPage() {
 
     const sanitized = phone.replace(/[^+\d]/g, "");
     const url = `tel:${sanitized}`;
-    // Using window.open with _self ensures the tel: URL triggers the phone dialer
-    window.open(url, "_self");
+    if (await confirmDialog("¿Permitir que la aplicación abra la app de teléfono?")) {
+      // Using location.assign ensures the tel: URL triggers the phone dialer
+      window.location.assign(url);
+    }
   };
 
   const deleteJanij = async (id: string) => {


### PR DESCRIPTION
## Summary
- prompt the user to allow opening the phone app before dialing

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68617f2c7be883318642045e65c8064e