### PR TITLE
refactor: share AI search logic across janijim pages

### DIFF
--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -5,6 +5,7 @@ import * as XLSX from "xlsx";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import useHighlightScroll from "@/hooks/useHighlightScroll";
+import { useAiSearch } from "@/hooks/useAiSearch";
 import Loader from "@/components/ui/loader";
 import {
   getJanijim,
@@ -60,8 +61,8 @@ export default function AsistenciaPage() {
   const [updating, setUpdating] = useState(false);
   const [search, setSearch] = useState("");
   const [showResults, setShowResults] = useState(false);
-  const [aiResults, setAiResults] = useState<string[]>([]);
-  const [aiLoading, setAiLoading] = useState(false);
+  const names = useMemo(() => janijim.map((j) => j.nombre), [janijim]);
+  const { aiResults, aiLoading } = useAiSearch(search, names);
   const [showTopButton, setShowTopButton] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
   const exportable = [
@@ -127,37 +128,6 @@ export default function AsistenciaPage() {
       })
       .finally(() => setLoading(false));
   }, [sesionId, proyectoId]);
-
-  useEffect(() => {
-    if (!search.trim()) {
-      setAiResults([]);
-      return;
-    }
-
-    const controller = new AbortController();
-    setAiLoading(true);
-
-    fetch("/api/search", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        query: search,
-        names: janijim.map((j) => j.nombre),
-      }),
-      signal: controller.signal,
-    })
-      .then((res) => res.json())
-      .then((d) => {
-        setAiResults(d.matches || []);
-        setAiLoading(false);
-      })
-      .catch(() => {
-        setAiResults([]);
-        setAiLoading(false);
-      });
-
-    return () => controller.abort();
-  }, [search, janijim]);
 
   const resultados = useMemo(() => {
     if (!search.trim()) return [];

--- a/src/hooks/useAiSearch.ts
+++ b/src/hooks/useAiSearch.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+export function useAiSearch(query: string, names: string[]) {
+  const [aiResults, setAiResults] = useState<string[]>([]);
+  const [aiLoading, setAiLoading] = useState(false);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setAiResults([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    setAiLoading(true);
+
+    fetch("/api/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: trimmed, names }),
+      signal: controller.signal,
+    })
+      .then((res) => res.json())
+      .then((d) => {
+        setAiResults(d.matches || []);
+        setAiLoading(false);
+      })
+      .catch(() => {
+        setAiResults([]);
+        setAiLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [query, names]);
+
+  return { aiResults, aiLoading };
+}
+


### PR DESCRIPTION
## Summary
- extract OpenAI search into reusable `useAiSearch` hook
- use the hook in janijim list and attendance pages for parallel suggestions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0fc9a06b483319579dc1fbb7f1f98