### PR TITLE
feat: use tags for attendance sessions

### DIFF
--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -304,7 +304,7 @@ export default function AsistenciaPage() {
       const url = URL.createObjectURL(new Blob([blob]));
       const a = document.createElement("a");
       a.href = url;
-      a.download = `asistencia-${sesion?.nombre || "sesion"}.xlsx`;
+      a.download = `${sesion?.nombre || "asistencia"}.xlsx`;
       a.click();
       URL.revokeObjectURL(url);
     };


### PR DESCRIPTION
## Summary
- allow adding and reusing tags when creating attendance sessions
- auto-generate session and export names with date, time and tags

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25a2f92dc8331b121574a0b4df815