### PR TITLE
fix: enable AI search on touch devices

### DIFF
--- a/src/app/proyecto/[id]/janijim/asistencia/page.tsx
+++ b/src/app/proyecto/[id]/janijim/asistencia/page.tsx
@@ -411,6 +411,10 @@ export default function AsistenciaPage() {
                 <li
                   key={r.id}
                   onMouseDown={() => seleccionar(r.id)}
+                  onTouchStart={(e) => {
+                    e.preventDefault();
+                    seleccionar(r.id);
+                  }}
                   className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
                 >
                   <span>{r.nombre}</span>
@@ -427,6 +431,11 @@ export default function AsistenciaPage() {
                     <Button
                       className="w-full"
                       onMouseDown={(e) => {
+                        e.preventDefault();
+                        setAiSearched(true);
+                        searchAi(search);
+                      }}
+                      onTouchStart={(e) => {
                         e.preventDefault();
                         setAiSearched(true);
                         searchAi(search);
@@ -458,6 +467,10 @@ export default function AsistenciaPage() {
                     <li
                       key={r.id}
                       onMouseDown={() => seleccionar(r.id)}
+                      onTouchStart={(e) => {
+                        e.preventDefault();
+                        seleccionar(r.id);
+                      }}
                       className="flex justify-between p-2 cursor-pointer hover:bg-gray-100"
                     >
                       <span>{r.nombre}</span>
@@ -480,6 +493,10 @@ export default function AsistenciaPage() {
                   <li
                     tabIndex={0}
                     onMouseDown={() => agregar(search.trim())}
+                    onTouchStart={(e) => {
+                      e.preventDefault();
+                      agregar(search.trim());
+                    }}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();

--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -506,6 +506,10 @@ export default function JanijimPage() {
                       key={r.id}
                       tabIndex={0}
                       onMouseDown={() => seleccionar(r.id)}
+                      onTouchStart={(e) => {
+                        e.preventDefault();
+                        seleccionar(r.id);
+                      }}
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
@@ -529,6 +533,11 @@ export default function JanijimPage() {
                         <Button
                           className="w-full"
                           onMouseDown={(e) => {
+                            e.preventDefault();
+                            setAiSearched(true);
+                            searchAi(search);
+                          }}
+                          onTouchStart={(e) => {
                             e.preventDefault();
                             setAiSearched(true);
                             searchAi(search);
@@ -565,6 +574,10 @@ export default function JanijimPage() {
                           key={r.id}
                           tabIndex={0}
                           onMouseDown={() => seleccionar(r.id)}
+                          onTouchStart={(e) => {
+                            e.preventDefault();
+                            seleccionar(r.id);
+                          }}
                           onKeyDown={(e) => {
                             if (e.key === "Enter" || e.key === " ") {
                               e.preventDefault();
@@ -594,6 +607,10 @@ export default function JanijimPage() {
                       <li
                         tabIndex={0}
                         onMouseDown={() => agregar(search.trim())}
+                        onTouchStart={(e) => {
+                          e.preventDefault();
+                          agregar(search.trim());
+                        }}
                         onKeyDown={(e) => {
                           if (e.key === "Enter" || e.key === " ") {
                             e.preventDefault();


### PR DESCRIPTION
## Summary
- handle `onTouchStart` for search results and AI search button so tapping doesn't hide suggestions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25a70a1ac8331a6c409e6c982f7e7