### PR TITLE
Fix Button imports and add variant support

### DIFF
--- a/src/app/proyecto/[id]/comidas/[restaurant]/page.tsx
+++ b/src/app/proyecto/[id]/comidas/[restaurant]/page.tsx
@@ -10,7 +10,7 @@ import {
   RestaurantRow,
   FoodOrderItemRow,
 } from "@/lib/supabase/comidas";
-import { Button } from "@/components/ui/button";
+import Button from "@/components/ui/button";
 import { showError } from "@/lib/alerts";
 import { toast } from "react-hot-toast";
 

--- a/src/app/proyecto/[id]/comidas/page.tsx
+++ b/src/app/proyecto/[id]/comidas/page.tsx
@@ -3,13 +3,14 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
+import { Categories } from "emoji-picker-react";
 import {
   getRestaurants,
   addRestaurant,
   DishOption,
   RestaurantRow,
 } from "@/lib/supabase/comidas";
-import { Button } from "@/components/ui/button";
+import Button from "@/components/ui/button";
 import Skeleton from "@/components/ui/skeleton";
 import {
   Sheet,
@@ -194,7 +195,7 @@ export default function ComidasIndexPage() {
                       <div className="absolute z-10 mt-2">
                         <EmojiPicker
                           lazyLoadEmojis
-                          categories={["food_drink"]}
+                          categories={[{ category: Categories.FOOD_DRINK, name: "Food & Drink" }]}
                           onEmojiClick={(e) => {
                             updateDish(i, "icono", e.emoji);
                             setPickerIndex(null);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,7 +3,15 @@ import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "primary" | "secondary" | "danger" | "success";
+  variant?:
+    | "primary"
+    | "secondary"
+    | "danger"
+    | "success"
+    | "ghost"
+    | "outline";
+  /** Optional size preset */
+  size?: "icon" | "sm";
   loading?: boolean;
   icon?: React.ReactNode;
   iconRight?: boolean;
@@ -11,6 +19,7 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 export default function Button({
   variant = "primary",
+  size,
   loading,
   icon,
   iconRight,
@@ -26,16 +35,22 @@ export default function Button({
     secondary: "bg-gray-200 text-gray-700 hover:bg-gray-300",
     danger: "bg-red-600 text-white hover:bg-red-700",
     success: "bg-green-600 text-white hover:bg-green-700",
+    ghost: "bg-transparent text-gray-700 hover:bg-gray-100",
+    outline: "border border-gray-300 bg-white text-gray-700 hover:bg-gray-50",
+  };
+  const sizes: Record<string, string> = {
+    icon: "h-9 w-9 p-0",
+    sm: "px-2 py-1 text-sm",
   };
 
   return (
     <button
       disabled={disabled || loading}
-      className={cn(base, variants[variant], className)}
+      className={cn(base, variants[variant], size && sizes[size], className)}
       {...props}
     >
       {!iconRight && (loading ? <Loader2 className="w-4 h-4 animate-spin" /> : icon)}
-      <span>{children}</span>
+      {size === "icon" ? children : <span>{children}</span>}
       {iconRight && (loading ? <Loader2 className="w-4 h-4 animate-spin" /> : icon)}
     </button>
   );

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -7,7 +7,7 @@ import { UserButton } from "@clerk/nextjs";
 import { navigationLinks as links } from "@/lib/navigationLinks";
 import { useState } from "react";
 import { Plus, X } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import Button from "@/components/ui/button";
 import { useSidebarLinks } from "@/hooks/useSidebarLinks";
 
 export default function Sidebar({ proyectoId }: { proyectoId: string }) {


### PR DESCRIPTION
## Summary
- use default `Button` import
- expand `Button` component variants and sizes
- fix emoji picker categories to avoid type errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a25d144fbc8331bb88bae305fe5b29