### PR TITLE
feat: mejorar flujo de comidas y pedidos

### DIFF
--- a/src/app/proyecto/[id]/comidas/page.tsx
+++ b/src/app/proyecto/[id]/comidas/page.tsx
@@ -30,7 +30,16 @@ const EmojiPicker = dynamic(() => import("emoji-picker-react"), {
 type DishForm = {
   nombre: string;
   icono: string;
-  sides: { nombre: string; variantes: string }[];
+};
+
+type SideForm = {
+  nombre: string;
+  variantes: string;
+};
+
+type DishSides = {
+  enabled: boolean;
+  sides: Set<number>;
 };
 
 export default function ComidasIndexPage() {
@@ -40,10 +49,11 @@ export default function ComidasIndexPage() {
   const [loading, setLoading] = useState(true);
   const [orderOpen, setOrderOpen] = useState(false);
   const [formOpen, setFormOpen] = useState(false);
+  const [step, setStep] = useState(1);
   const [nombre, setNombre] = useState("");
-  const [dishes, setDishes] = useState<DishForm[]>([
-    { nombre: "", icono: "", sides: [] },
-  ]);
+  const [dishes, setDishes] = useState<DishForm[]>([{ nombre: "", icono: "" }]);
+  const [sides, setSides] = useState<SideForm[]>([]);
+  const [dishSides, setDishSides] = useState<Record<number, DishSides>>({});
   const [pickerIndex, setPickerIndex] = useState<number | null>(null);
 
   useEffect(() => {
@@ -55,8 +65,22 @@ export default function ComidasIndexPage() {
       .finally(() => setLoading(false));
   }, [proyectoId]);
 
+  useEffect(() => {
+    setDishSides((prev) => {
+      const copy = { ...prev };
+      Object.values(copy).forEach((value) => {
+        if (value.enabled) {
+          sides.forEach((_, i) => {
+            if (!value.sides.has(i)) value.sides.add(i);
+          });
+        }
+      });
+      return { ...copy };
+    });
+  }, [sides]);
+
   const addDish = () =>
-    setDishes((prev) => [...prev, { nombre: "", icono: "", sides: [] }]);
+    setDishes((prev) => [...prev, { nombre: "", icono: "" }]);
 
   const updateDish = (i: number, field: keyof DishForm, value: string) => {
     setDishes((prev) => {
@@ -66,47 +90,72 @@ export default function ComidasIndexPage() {
     });
   };
 
-  const addSide = (dishIdx: number) => {
-    setDishes((prev) => {
+  const addSide = () =>
+    setSides((prev) => [...prev, { nombre: "", variantes: "" }]);
+
+  const updateSide = (
+    sideIdx: number,
+    field: keyof SideForm,
+    value: string
+  ) => {
+    setSides((prev) => {
       const copy = [...prev];
-      copy[dishIdx].sides.push({ nombre: "", variantes: "" });
+      copy[sideIdx] = { ...copy[sideIdx], [field]: value } as SideForm;
       return copy;
     });
   };
 
-  const updateSide = (
-    dishIdx: number,
-    sideIdx: number,
-    field: "nombre" | "variantes",
-    value: string
-  ) => {
-    setDishes((prev) => {
-      const copy = [...prev];
-      const sides = [...copy[dishIdx].sides];
-      sides[sideIdx] = { ...sides[sideIdx], [field]: value };
-      copy[dishIdx] = { ...copy[dishIdx], sides };
+  const toggleHasSides = (dishIdx: number, enabled: boolean) => {
+    setDishSides((prev) => {
+      const copy = { ...prev };
+      copy[dishIdx] = {
+        enabled,
+        sides: enabled
+          ? new Set(sides.map((_, i) => i))
+          : new Set(),
+      };
       return copy;
+    });
+  };
+
+  const toggleDishSide = (dishIdx: number, sideIdx: number) => {
+    setDishSides((prev) => {
+      const copy = { ...prev };
+      const info = copy[dishIdx];
+      if (!info) return prev;
+      if (info.sides.has(sideIdx)) info.sides.delete(sideIdx);
+      else info.sides.add(sideIdx);
+      return { ...copy, [dishIdx]: { ...info, sides: new Set(info.sides) } };
     });
   };
 
   const submitRestaurant = async () => {
     if (!proyectoId) return;
-    const platos: DishOption[] = dishes.map((d) => ({
+    const platos: DishOption[] = dishes.map((d, i) => ({
       nombre: d.nombre,
       icono: d.icono || "🍽️",
-      guarniciones: d.sides.map((s) => ({
-        nombre: s.nombre,
-        variantes: s.variantes
-          ? s.variantes.split(",").map((v) => v.trim()).filter(Boolean)
+      guarniciones:
+        dishSides[i]?.enabled
+          ? Array.from(dishSides[i].sides).map((idx) => ({
+              nombre: sides[idx].nombre,
+              variantes: sides[idx].variantes
+                ? sides[idx].variantes
+                    .split(",")
+                    .map((v) => v.trim())
+                    .filter(Boolean)
+                : [],
+            }))
           : [],
-      })),
     }));
     addRestaurant(proyectoId, nombre, platos)
       .then((r) => {
         setRestaurants((prev) => [...prev, r]);
         setFormOpen(false);
+        setStep(1);
         setNombre("");
-        setDishes([{ nombre: "", icono: "", sides: [] }]);
+        setDishes([{ nombre: "", icono: "" }]);
+        setSides([]);
+        setDishSides({});
         toast.success("Restaurante creado");
       })
       .catch(() => showError("Error creando restaurante"));
@@ -158,90 +207,150 @@ export default function ComidasIndexPage() {
         </SheetContent>
       </Sheet>
 
-      <Sheet open={formOpen} onOpenChange={setFormOpen}>
+      <Sheet
+        open={formOpen}
+        onOpenChange={(o) => {
+          setFormOpen(o);
+          if (!o) setStep(1);
+        }}
+      >
         <SheetContent side="bottom" className="w-full max-h-screen overflow-auto">
           <SheetHeader>
             <SheetTitle>Nuevo restaurante</SheetTitle>
           </SheetHeader>
           <div className="p-4 space-y-4">
-            <input
-              type="text"
-              value={nombre}
-              onChange={(e) => setNombre(e.target.value)}
-              placeholder="Nombre del restaurante"
-              className="w-full border rounded p-2"
-            />
-            {dishes.map((d, i) => (
-              <div key={i} className="border rounded p-3 space-y-2">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="text"
-                    value={d.nombre}
-                    onChange={(e) => updateDish(i, "nombre", e.target.value)}
-                    placeholder="Plato principal"
-                    className="flex-1 border rounded p-2"
-                  />
-                  <div className="relative">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setPickerIndex((p) => (p === i ? null : i))
-                      }
-                      className="border rounded p-2 min-w-12"
-                    >
-                      {d.icono || "🍽️"}
-                    </button>
-                    {pickerIndex === i && (
-                      <div className="absolute z-10 mt-2">
-                        <EmojiPicker
-                          lazyLoadEmojis
-                          categories={[{ category: Categories.FOOD_DRINK, name: "Food & Drink" }]}
-                          onEmojiClick={(e) => {
-                            updateDish(i, "icono", e.emoji);
-                            setPickerIndex(null);
-                          }}
-                        />
+            {step === 1 && (
+              <>
+                <input
+                  type="text"
+                  value={nombre}
+                  onChange={(e) => setNombre(e.target.value)}
+                  placeholder="Nombre del restaurante"
+                  className="w-full border rounded p-2"
+                />
+                {dishes.map((d, i) => (
+                  <div key={i} className="border rounded p-3 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="text"
+                        value={d.nombre}
+                        onChange={(e) => updateDish(i, "nombre", e.target.value)}
+                        placeholder="Plato principal"
+                        className="flex-1 border rounded p-2"
+                      />
+                      <div className="relative">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setPickerIndex((p) => (p === i ? null : i))
+                          }
+                          className="border rounded p-2 min-w-12"
+                        >
+                          {d.icono || "🍽️"}
+                        </button>
+                        {pickerIndex === i && (
+                          <div className="absolute z-10 mt-2 overflow-x-auto">
+                            <div className="min-w-[352px]">
+                              <EmojiPicker
+                                lazyLoadEmojis
+                                categories={[{ category: Categories.FOOD_DRINK, name: "Food & Drink" }]}
+                                onEmojiClick={(e) => {
+                                  updateDish(i, "icono", e.emoji);
+                                  setPickerIndex(null);
+                                }}
+                              />
+                            </div>
+                          </div>
+                        )}
                       </div>
-                    )}
+                    </div>
                   </div>
-                </div>
-                {d.sides.map((s, j) => (
-                  <div key={j} className="ml-4 space-y-1">
+                ))}
+                <Button variant="outline" onClick={addDish}>
+                  Agregar plato
+                </Button>
+              </>
+            )}
+
+            {step === 2 && (
+              <>
+                {sides.map((s, i) => (
+                  <div key={i} className="border rounded p-3 space-y-2">
                     <input
                       type="text"
                       value={s.nombre}
-                      onChange={(e) =>
-                        updateSide(i, j, "nombre", e.target.value)
-                      }
+                      onChange={(e) => updateSide(i, "nombre", e.target.value)}
                       placeholder="Guarnición"
                       className="w-full border rounded p-2"
                     />
                     <input
                       type="text"
                       value={s.variantes}
-                      onChange={(e) =>
-                        updateSide(i, j, "variantes", e.target.value)
-                      }
+                      onChange={(e) => updateSide(i, "variantes", e.target.value)}
                       placeholder="Variantes (separadas por coma)"
                       className="w-full border rounded p-2"
                     />
                   </div>
                 ))}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => addSide(i)}
-                >
+                <Button variant="outline" onClick={addSide}>
                   Agregar guarnición
                 </Button>
-              </div>
-            ))}
-            <Button variant="outline" onClick={addDish}>
-              Agregar plato
-            </Button>
+              </>
+            )}
+
+            {step === 3 && (
+              <>
+                {dishes.map((d, i) => (
+                  <div key={i} className="border rounded p-3 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span>
+                        {d.icono || "🍽️"} {d.nombre}
+                      </span>
+                      <label className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={dishSides[i]?.enabled || false}
+                          onChange={(e) =>
+                            toggleHasSides(i, e.target.checked)
+                          }
+                        />
+                        Lleva guarnición
+                      </label>
+                    </div>
+                    {dishSides[i]?.enabled && sides.length > 0 && (
+                      <div className="grid grid-cols-2 gap-1">
+                        {sides.map((s, j) => (
+                          <label
+                            key={j}
+                            className="flex items-center gap-2 text-sm"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={dishSides[i].sides.has(j)}
+                              onChange={() => toggleDishSide(i, j)}
+                            />
+                            {s.nombre}
+                          </label>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </>
+            )}
           </div>
-          <SheetFooter>
-            <Button onClick={submitRestaurant}>Crear restaurante</Button>
+          <SheetFooter className="flex justify-between">
+            {step > 1 && (
+              <Button variant="secondary" onClick={() => setStep(step - 1)}>
+                Anterior
+              </Button>
+            )}
+            {step < 3 && (
+              <Button onClick={() => setStep(step + 1)}>Siguiente</Button>
+            )}
+            {step === 3 && (
+              <Button onClick={submitRestaurant}>Crear restaurante</Button>
+            )}
           </SheetFooter>
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
## Summary
- dividir creación de restaurante en pasos para platos, guarniciones y relación con checkboxes
- permitir scroll horizontal en selector de emojis para mejor soporte mobile
- agrupar ítems repetidos en pedidos y compartir resumen por WhatsApp copiado al portapapeles

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a261de4fb48331b234ab742fe2582f