### PR TITLE
feat: full page restaurant creation with card layout

### DIFF
--- a/src/app/proyecto/[id]/comidas/nuevo/page.tsx
+++ b/src/app/proyecto/[id]/comidas/nuevo/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
+import { Categories } from "emoji-picker-react";
+import { addRestaurant, DishOption } from "@/lib/supabase/comidas";
+import Button from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { showError } from "@/lib/alerts";
+import { toast } from "react-hot-toast";
+
+const EmojiPicker = dynamic(() => import("emoji-picker-react"), { ssr: false });
+
+type DishForm = { nombre: string; icono: string };
+type SideForm = { nombre: string; variantes: string };
+type DishSides = { enabled: boolean; sides: Set<number> };
+
+export default function NuevoRestaurantePage() {
+  const { id: proyectoId } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [step, setStep] = useState(1);
+  const [nombre, setNombre] = useState("");
+  const [dishes, setDishes] = useState<DishForm[]>([{ nombre: "", icono: "" }]);
+  const [sides, setSides] = useState<SideForm[]>([]);
+  const [dishSides, setDishSides] = useState<Record<number, DishSides>>({});
+  const [pickerIndex, setPickerIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    setDishSides((prev) => {
+      const copy = { ...prev };
+      Object.values(copy).forEach((value) => {
+        if (value.enabled) {
+          sides.forEach((_, i) => {
+            if (!value.sides.has(i)) value.sides.add(i);
+          });
+        }
+      });
+      return { ...copy };
+    });
+  }, [sides]);
+
+  const addDish = () => setDishes((prev) => [...prev, { nombre: "", icono: "" }]);
+
+  const updateDish = (i: number, field: keyof DishForm, value: string) => {
+    setDishes((prev) => {
+      const copy = [...prev];
+      copy[i] = { ...copy[i], [field]: value } as DishForm;
+      return copy;
+    });
+  };
+
+  const addSide = () => setSides((prev) => [...prev, { nombre: "", variantes: "" }]);
+
+  const updateSide = (sideIdx: number, field: keyof SideForm, value: string) => {
+    setSides((prev) => {
+      const copy = [...prev];
+      copy[sideIdx] = { ...copy[sideIdx], [field]: value } as SideForm;
+      return copy;
+    });
+  };
+
+  const toggleHasSides = (dishIdx: number, enabled: boolean) => {
+    setDishSides((prev) => {
+      const copy = { ...prev };
+      copy[dishIdx] = {
+        enabled,
+        sides: enabled ? new Set(sides.map((_, i) => i)) : new Set(),
+      };
+      return copy;
+    });
+  };
+
+  const toggleDishSide = (dishIdx: number, sideIdx: number) => {
+    setDishSides((prev) => {
+      const copy = { ...prev };
+      const info = copy[dishIdx];
+      if (!info) return prev;
+      if (info.sides.has(sideIdx)) info.sides.delete(sideIdx);
+      else info.sides.add(sideIdx);
+      return { ...copy, [dishIdx]: { ...info, sides: new Set(info.sides) } };
+    });
+  };
+
+  const submitRestaurant = async () => {
+    if (!proyectoId) return;
+    const platos: DishOption[] = dishes.map((d, i) => ({
+      nombre: d.nombre,
+      icono: d.icono || "🍽️",
+      guarniciones:
+        dishSides[i]?.enabled
+          ? Array.from(dishSides[i].sides).map((idx) => ({
+              nombre: sides[idx].nombre,
+              variantes: sides[idx].variantes
+                ? sides[idx].variantes.split(",").map((v) => v.trim()).filter(Boolean)
+                : [],
+            }))
+          : [],
+    }));
+    addRestaurant(proyectoId, nombre, platos)
+      .then(() => {
+        toast.success("Restaurante creado");
+        router.back();
+      })
+      .catch(() => showError("Error creando restaurante"));
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-blue-900">Nuevo restaurante</h1>
+
+      {step === 1 && (
+        <>
+          <Card>
+            <CardContent>
+              <input
+                type="text"
+                value={nombre}
+                onChange={(e) => setNombre(e.target.value)}
+                placeholder="Nombre del restaurante"
+                className="w-full border rounded p-2"
+              />
+            </CardContent>
+          </Card>
+          {dishes.map((d, i) => (
+            <Card key={i}>
+              <CardContent>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={d.nombre}
+                    onChange={(e) => updateDish(i, "nombre", e.target.value)}
+                    placeholder="Plato principal"
+                    className="flex-1 border rounded p-2"
+                  />
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => setPickerIndex((p) => (p === i ? null : i))}
+                      className="border rounded p-2 min-w-12"
+                    >
+                      {d.icono || "🍽️"}
+                    </button>
+                    {pickerIndex === i && (
+                      <div className="absolute z-10 mt-2 overflow-x-auto">
+                        <div className="min-w-[352px]">
+                          <EmojiPicker
+                            lazyLoadEmojis
+                            categories={[{ category: Categories.FOOD_DRINK, name: "Food & Drink" }]}
+                            onEmojiClick={(e) => {
+                              updateDish(i, "icono", e.emoji);
+                              setPickerIndex(null);
+                            }}
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+          <Button variant="outline" onClick={addDish}>
+            Agregar plato
+          </Button>
+        </>
+      )}
+
+      {step === 2 && (
+        <>
+          {sides.map((s, i) => (
+            <Card key={i}>
+              <CardContent>
+                <input
+                  type="text"
+                  value={s.nombre}
+                  onChange={(e) => updateSide(i, "nombre", e.target.value)}
+                  placeholder="Guarnición"
+                  className="w-full border rounded p-2"
+                />
+                <input
+                  type="text"
+                  value={s.variantes}
+                  onChange={(e) => updateSide(i, "variantes", e.target.value)}
+                  placeholder="Variantes (separadas por coma)"
+                  className="w-full border rounded p-2"
+                />
+              </CardContent>
+            </Card>
+          ))}
+          <Button variant="outline" onClick={addSide}>
+            Agregar guarnición
+          </Button>
+        </>
+      )}
+
+      {step === 3 && (
+        <>
+          {dishes.map((d, i) => (
+            <Card key={i}>
+              <CardHeader>
+                <CardTitle>
+                  {d.icono || "🍽️"} {d.nombre}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={dishSides[i]?.enabled || false}
+                    onChange={(e) => toggleHasSides(i, e.target.checked)}
+                  />
+                  Lleva guarnición
+                </label>
+                {dishSides[i]?.enabled && sides.length > 0 && (
+                  <div className="grid grid-cols-2 gap-1">
+                    {sides.map((s, j) => (
+                      <label key={j} className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={dishSides[i].sides.has(j)}
+                          onChange={() => toggleDishSide(i, j)}
+                        />
+                        {s.nombre}
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </>
+      )}
+
+      <div className="flex justify-between">
+        {step > 1 && (
+          <Button variant="secondary" onClick={() => setStep(step - 1)}>
+            Anterior
+          </Button>
+        )}
+        {step < 3 && <Button onClick={() => setStep(step + 1)}>Siguiente</Button>}
+        {step === 3 && <Button onClick={submitRestaurant}>Crear restaurante</Button>}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/proyecto/[id]/comidas/page.tsx
+++ b/src/app/proyecto/[id]/comidas/page.tsx
@@ -2,14 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import dynamic from "next/dynamic";
-import { Categories } from "emoji-picker-react";
-import {
-  getRestaurants,
-  addRestaurant,
-  DishOption,
-  RestaurantRow,
-} from "@/lib/supabase/comidas";
+import { getRestaurants, RestaurantRow } from "@/lib/supabase/comidas";
 import Button from "@/components/ui/button";
 import Skeleton from "@/components/ui/skeleton";
 import {
@@ -20,27 +13,6 @@ import {
   SheetFooter,
 } from "@/components/ui/sheet";
 import { PlusCircle } from "lucide-react";
-import { showError } from "@/lib/alerts";
-import { toast } from "react-hot-toast";
-
-const EmojiPicker = dynamic(() => import("emoji-picker-react"), {
-  ssr: false,
-});
-
-type DishForm = {
-  nombre: string;
-  icono: string;
-};
-
-type SideForm = {
-  nombre: string;
-  variantes: string;
-};
-
-type DishSides = {
-  enabled: boolean;
-  sides: Set<number>;
-};
 
 export default function ComidasIndexPage() {
   const { id: proyectoId } = useParams<{ id: string }>();
@@ -48,13 +20,6 @@ export default function ComidasIndexPage() {
   const [restaurants, setRestaurants] = useState<RestaurantRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [orderOpen, setOrderOpen] = useState(false);
-  const [formOpen, setFormOpen] = useState(false);
-  const [step, setStep] = useState(1);
-  const [nombre, setNombre] = useState("");
-  const [dishes, setDishes] = useState<DishForm[]>([{ nombre: "", icono: "" }]);
-  const [sides, setSides] = useState<SideForm[]>([]);
-  const [dishSides, setDishSides] = useState<Record<number, DishSides>>({});
-  const [pickerIndex, setPickerIndex] = useState<number | null>(null);
 
   useEffect(() => {
     if (!proyectoId) return;
@@ -65,101 +30,6 @@ export default function ComidasIndexPage() {
       .finally(() => setLoading(false));
   }, [proyectoId]);
 
-  useEffect(() => {
-    setDishSides((prev) => {
-      const copy = { ...prev };
-      Object.values(copy).forEach((value) => {
-        if (value.enabled) {
-          sides.forEach((_, i) => {
-            if (!value.sides.has(i)) value.sides.add(i);
-          });
-        }
-      });
-      return { ...copy };
-    });
-  }, [sides]);
-
-  const addDish = () =>
-    setDishes((prev) => [...prev, { nombre: "", icono: "" }]);
-
-  const updateDish = (i: number, field: keyof DishForm, value: string) => {
-    setDishes((prev) => {
-      const copy = [...prev];
-      copy[i] = { ...copy[i], [field]: value } as DishForm;
-      return copy;
-    });
-  };
-
-  const addSide = () =>
-    setSides((prev) => [...prev, { nombre: "", variantes: "" }]);
-
-  const updateSide = (
-    sideIdx: number,
-    field: keyof SideForm,
-    value: string
-  ) => {
-    setSides((prev) => {
-      const copy = [...prev];
-      copy[sideIdx] = { ...copy[sideIdx], [field]: value } as SideForm;
-      return copy;
-    });
-  };
-
-  const toggleHasSides = (dishIdx: number, enabled: boolean) => {
-    setDishSides((prev) => {
-      const copy = { ...prev };
-      copy[dishIdx] = {
-        enabled,
-        sides: enabled
-          ? new Set(sides.map((_, i) => i))
-          : new Set(),
-      };
-      return copy;
-    });
-  };
-
-  const toggleDishSide = (dishIdx: number, sideIdx: number) => {
-    setDishSides((prev) => {
-      const copy = { ...prev };
-      const info = copy[dishIdx];
-      if (!info) return prev;
-      if (info.sides.has(sideIdx)) info.sides.delete(sideIdx);
-      else info.sides.add(sideIdx);
-      return { ...copy, [dishIdx]: { ...info, sides: new Set(info.sides) } };
-    });
-  };
-
-  const submitRestaurant = async () => {
-    if (!proyectoId) return;
-    const platos: DishOption[] = dishes.map((d, i) => ({
-      nombre: d.nombre,
-      icono: d.icono || "🍽️",
-      guarniciones:
-        dishSides[i]?.enabled
-          ? Array.from(dishSides[i].sides).map((idx) => ({
-              nombre: sides[idx].nombre,
-              variantes: sides[idx].variantes
-                ? sides[idx].variantes
-                    .split(",")
-                    .map((v) => v.trim())
-                    .filter(Boolean)
-                : [],
-            }))
-          : [],
-    }));
-    addRestaurant(proyectoId, nombre, platos)
-      .then((r) => {
-        setRestaurants((prev) => [...prev, r]);
-        setFormOpen(false);
-        setStep(1);
-        setNombre("");
-        setDishes([{ nombre: "", icono: "" }]);
-        setSides([]);
-        setDishSides({});
-        toast.success("Restaurante creado");
-      })
-      .catch(() => showError("Error creando restaurante"));
-  };
 
   return (
     <div className="space-y-6">
@@ -200,157 +70,12 @@ export default function ComidasIndexPage() {
             ))}
           </div>
           <SheetFooter>
-            <Button variant="secondary" onClick={() => setFormOpen(true)}>
+            <Button
+              variant="secondary"
+              onClick={() => router.push(`./comidas/nuevo`)}
+            >
               Agregar restaurante
             </Button>
-          </SheetFooter>
-        </SheetContent>
-      </Sheet>
-
-      <Sheet
-        open={formOpen}
-        onOpenChange={(o) => {
-          setFormOpen(o);
-          if (!o) setStep(1);
-        }}
-      >
-        <SheetContent side="bottom" className="w-full max-h-screen overflow-auto">
-          <SheetHeader>
-            <SheetTitle>Nuevo restaurante</SheetTitle>
-          </SheetHeader>
-          <div className="p-4 space-y-4">
-            {step === 1 && (
-              <>
-                <input
-                  type="text"
-                  value={nombre}
-                  onChange={(e) => setNombre(e.target.value)}
-                  placeholder="Nombre del restaurante"
-                  className="w-full border rounded p-2"
-                />
-                {dishes.map((d, i) => (
-                  <div key={i} className="border rounded p-3 space-y-2">
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="text"
-                        value={d.nombre}
-                        onChange={(e) => updateDish(i, "nombre", e.target.value)}
-                        placeholder="Plato principal"
-                        className="flex-1 border rounded p-2"
-                      />
-                      <div className="relative">
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setPickerIndex((p) => (p === i ? null : i))
-                          }
-                          className="border rounded p-2 min-w-12"
-                        >
-                          {d.icono || "🍽️"}
-                        </button>
-                        {pickerIndex === i && (
-                          <div className="absolute z-10 mt-2 overflow-x-auto">
-                            <div className="min-w-[352px]">
-                              <EmojiPicker
-                                lazyLoadEmojis
-                                categories={[{ category: Categories.FOOD_DRINK, name: "Food & Drink" }]}
-                                onEmojiClick={(e) => {
-                                  updateDish(i, "icono", e.emoji);
-                                  setPickerIndex(null);
-                                }}
-                              />
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                ))}
-                <Button variant="outline" onClick={addDish}>
-                  Agregar plato
-                </Button>
-              </>
-            )}
-
-            {step === 2 && (
-              <>
-                {sides.map((s, i) => (
-                  <div key={i} className="border rounded p-3 space-y-2">
-                    <input
-                      type="text"
-                      value={s.nombre}
-                      onChange={(e) => updateSide(i, "nombre", e.target.value)}
-                      placeholder="Guarnición"
-                      className="w-full border rounded p-2"
-                    />
-                    <input
-                      type="text"
-                      value={s.variantes}
-                      onChange={(e) => updateSide(i, "variantes", e.target.value)}
-                      placeholder="Variantes (separadas por coma)"
-                      className="w-full border rounded p-2"
-                    />
-                  </div>
-                ))}
-                <Button variant="outline" onClick={addSide}>
-                  Agregar guarnición
-                </Button>
-              </>
-            )}
-
-            {step === 3 && (
-              <>
-                {dishes.map((d, i) => (
-                  <div key={i} className="border rounded p-3 space-y-2">
-                    <div className="flex items-center justify-between">
-                      <span>
-                        {d.icono || "🍽️"} {d.nombre}
-                      </span>
-                      <label className="flex items-center gap-2 text-sm">
-                        <input
-                          type="checkbox"
-                          checked={dishSides[i]?.enabled || false}
-                          onChange={(e) =>
-                            toggleHasSides(i, e.target.checked)
-                          }
-                        />
-                        Lleva guarnición
-                      </label>
-                    </div>
-                    {dishSides[i]?.enabled && sides.length > 0 && (
-                      <div className="grid grid-cols-2 gap-1">
-                        {sides.map((s, j) => (
-                          <label
-                            key={j}
-                            className="flex items-center gap-2 text-sm"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={dishSides[i].sides.has(j)}
-                              onChange={() => toggleDishSide(i, j)}
-                            />
-                            {s.nombre}
-                          </label>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </>
-            )}
-          </div>
-          <SheetFooter className="flex justify-between">
-            {step > 1 && (
-              <Button variant="secondary" onClick={() => setStep(step - 1)}>
-                Anterior
-              </Button>
-            )}
-            {step < 3 && (
-              <Button onClick={() => setStep(step + 1)}>Siguiente</Button>
-            )}
-            {step === 3 && (
-              <Button onClick={submitRestaurant}>Crear restaurante</Button>
-            )}
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("border rounded-lg bg-white p-4 shadow-sm", className)} {...props} />;
+}
+
+export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mb-2", className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn("text-lg font-semibold", className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("space-y-2", className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mt-4 flex justify-end gap-2", className)} {...props} />;
+}


### PR DESCRIPTION
## Summary
- replace bottom sheet restaurant form with a dedicated page
- add reusable card component for cleaner layout
- link from order sheet to full-screen restaurant creator

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2669d21e483319c7e01359b825d44