### PR TITLE
feat: support multi-select side variants

### DIFF
--- a/src/app/proyecto/[id]/comidas/[restaurant]/page.tsx
+++ b/src/app/proyecto/[id]/comidas/[restaurant]/page.tsx
@@ -18,6 +18,7 @@ interface ItemForm {
   plato: string;
   guarnicion?: string;
   variante?: string;
+  variantes: string[];
   pedido_por: string;
 }
 
@@ -33,6 +34,7 @@ export default function RestaurantOrderPage() {
     plato: "",
     guarnicion: "",
     variante: "",
+    variantes: [],
     pedido_por: "",
   });
 
@@ -93,10 +95,22 @@ export default function RestaurantOrderPage() {
   const agregarItem = async () => {
     if (!orderId) return;
     if (!form.plato || !form.pedido_por) return;
-    addOrderItem(orderId, form)
+    const variant = multiple ? form.variantes.join(", ") : form.variante;
+    addOrderItem(orderId, {
+      plato: form.plato,
+      guarnicion: form.guarnicion,
+      variante: variant,
+      pedido_por: form.pedido_por,
+    })
       .then((it) => {
         setItems((prev) => [...prev, it]);
-        setForm({ plato: "", guarnicion: "", variante: "", pedido_por: "" });
+        setForm({
+          plato: "",
+          guarnicion: "",
+          variante: "",
+          variantes: [],
+          pedido_por: "",
+        });
         toast.success("Agregado");
       })
       .catch(() => showError("Error agregando"));
@@ -107,6 +121,7 @@ export default function RestaurantOrderPage() {
   const sides = selectedDish?.guarniciones || [];
   const selectedSide = sides.find((s) => s.nombre === form.guarnicion);
   const variantes = selectedSide?.variantes || [];
+  const multiple = selectedSide?.multiple;
 
   return (
     <div className="space-y-6">
@@ -119,7 +134,13 @@ export default function RestaurantOrderPage() {
           <select
             value={form.plato}
             onChange={(e) =>
-              setForm((f) => ({ ...f, plato: e.target.value, guarnicion: "", variante: "" }))
+              setForm((f) => ({
+                ...f,
+                plato: e.target.value,
+                guarnicion: "",
+                variante: "",
+                variantes: [],
+              }))
             }
             className="border rounded p-2 flex-1"
           >
@@ -134,7 +155,12 @@ export default function RestaurantOrderPage() {
             <select
               value={form.guarnicion}
               onChange={(e) =>
-                setForm((f) => ({ ...f, guarnicion: e.target.value, variante: "" }))
+                setForm((f) => ({
+                  ...f,
+                  guarnicion: e.target.value,
+                  variante: "",
+                  variantes: [],
+                }))
               }
               className="border rounded p-2 flex-1"
             >
@@ -146,7 +172,7 @@ export default function RestaurantOrderPage() {
               ))}
             </select>
           )}
-          {variantes.length > 0 && (
+          {variantes.length > 0 && !multiple && (
             <select
               value={form.variante}
               onChange={(e) =>
@@ -161,6 +187,27 @@ export default function RestaurantOrderPage() {
                 </option>
               ))}
             </select>
+          )}
+          {variantes.length > 0 && multiple && (
+            <div className="flex flex-wrap gap-2 flex-1">
+              {variantes.map((v) => (
+                <label key={v} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={form.variantes?.includes(v) || false}
+                    onChange={(e) =>
+                      setForm((f) => {
+                        const set = new Set(f.variantes);
+                        if (e.target.checked) set.add(v);
+                        else set.delete(v);
+                        return { ...f, variantes: Array.from(set) };
+                      })
+                    }
+                  />
+                  {v}
+                </label>
+              ))}
+            </div>
           )}
         </div>
         <input

--- a/src/app/proyecto/[id]/comidas/nuevo/page.tsx
+++ b/src/app/proyecto/[id]/comidas/nuevo/page.tsx
@@ -13,7 +13,7 @@ import { toast } from "react-hot-toast";
 const EmojiPicker = dynamic(() => import("emoji-picker-react"), { ssr: false });
 
 type DishForm = { nombre: string; icono: string };
-type SideForm = { nombre: string; variantes: string };
+type SideForm = { nombre: string; variantes: string; multiple: boolean };
 type DishSides = { enabled: boolean; sides: Set<number> };
 
 export default function NuevoRestaurantePage() {
@@ -50,9 +50,14 @@ export default function NuevoRestaurantePage() {
     });
   };
 
-  const addSide = () => setSides((prev) => [...prev, { nombre: "", variantes: "" }]);
+  const addSide = () =>
+    setSides((prev) => [...prev, { nombre: "", variantes: "", multiple: false }]);
 
-  const updateSide = (sideIdx: number, field: keyof SideForm, value: string) => {
+  const updateSide = (
+    sideIdx: number,
+    field: keyof SideForm,
+    value: string | boolean,
+  ) => {
     setSides((prev) => {
       const copy = [...prev];
       copy[sideIdx] = { ...copy[sideIdx], [field]: value } as SideForm;
@@ -94,6 +99,7 @@ export default function NuevoRestaurantePage() {
               variantes: sides[idx].variantes
                 ? sides[idx].variantes.split(",").map((v) => v.trim()).filter(Boolean)
                 : [],
+              multiple: sides[idx].multiple,
             }))
           : [],
     }));
@@ -185,6 +191,14 @@ export default function NuevoRestaurantePage() {
                   placeholder="Variantes (separadas por coma)"
                   className="w-full border rounded p-2"
                 />
+                <label className="flex items-center gap-2 text-sm mt-2">
+                  <input
+                    type="checkbox"
+                    checked={s.multiple}
+                    onChange={(e) => updateSide(i, "multiple", e.target.checked)}
+                  />
+                  Selección múltiple
+                </label>
               </CardContent>
             </Card>
           ))}

--- a/src/lib/supabase/comidas.ts
+++ b/src/lib/supabase/comidas.ts
@@ -3,6 +3,7 @@ import { supabase } from "@/lib/supabase";
 export interface SideOption {
   nombre: string;
   variantes?: string[];
+  multiple?: boolean;
 }
 
 export interface DishOption {


### PR DESCRIPTION
## Summary
- allow sides to specify single or multiple variant selections
- add checkbox UI when creating restaurants to mark sides as multi-select
- permit choosing multiple variants for a side when ordering

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a26a0cbe208331bbf89e238c9dd807