### PR TITLE
Fix janij parent call tel link encoding

### DIFF
--- a/src/app/proyecto/[id]/janijim/page.tsx
+++ b/src/app/proyecto/[id]/janijim/page.tsx
@@ -339,16 +339,25 @@ export default function JanijimPage() {
       toast.error(fallbackMsg);
       return;
     }
+
     const cleanNumber = sanitized.replace(/[^+\d]/g, "");
-    const digitsOnly = cleanNumber.startsWith("+")
-      ? cleanNumber.slice(1)
-      : cleanNumber;
-    if (!digitsOnly) {
+    if (!cleanNumber) {
       toast.error(fallbackMsg);
       return;
     }
+
+    const normalized = cleanNumber.startsWith("+")
+      ? `+${cleanNumber.slice(1).replace(/\+/g, "")}`
+      : cleanNumber.replace(/\+/g, "");
+
+    if (!normalized || normalized === "+") {
+      toast.error(fallbackMsg);
+      return;
+    }
+
     const PRIVATE_CALL_PREFIX = "#31#";
-    const url = `tel:${PRIVATE_CALL_PREFIX}${digitsOnly}`;
+    const callSequence = `${PRIVATE_CALL_PREFIX}${normalized}`;
+    const url = `tel:${encodeURIComponent(callSequence)}`;
     window.location.assign(url);
   };
 


### PR DESCRIPTION
## Summary
- normalize parent phone numbers before dialing and encode the tel URI so the private call prefix works again

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e53bf6988083318aa23478ea1587c9